### PR TITLE
Feature/todak 155/diary find by date

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/DiaryErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/DiaryErrorSpec.java
@@ -17,7 +17,9 @@ public enum DiaryErrorSpec implements ErrorSpec {
       HttpStatus.BAD_REQUEST,
       "DIARY-002",
       "일기 삭제에 실패했습니다.",
-      "사용자가 삭제하려는 일기의 작성자가 아니거나, 삭제하려는 일기가 없습니다.");
+      "사용자가 삭제하려는 일기의 작성자가 아니거나, 삭제하려는 일기가 없습니다."),
+  DIARY_NOT_FOUND(
+      HttpStatus.BAD_REQUEST, "DIARY-003", "일기를 찾을 수 없습니다.", "사용자가 조회하려는 일기를 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryEmotion.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryEmotion.java
@@ -1,10 +1,5 @@
 package com.heartsave.todaktodak_api.diary.constant;
 
 public enum DiaryEmotion {
-  JOY("joy");
-  private final String emotion;
-
-  DiaryEmotion(String emotion) {
-    this.emotion = emotion;
-  }
+  JOY;
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryEmotion.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryEmotion.java
@@ -1,5 +1,11 @@
 package com.heartsave.todaktodak_api.diary.constant;
 
 public enum DiaryEmotion {
-  JOY;
+  JOY("joy");
+
+  private final String emotion;
+
+  DiaryEmotion(String emotion) {
+    this.emotion = emotion;
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryReactionType.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryReactionType.java
@@ -1,0 +1,8 @@
+package com.heartsave.todaktodak_api.diary.constant;
+
+public enum DiaryReactionType {
+  LIKE,
+  SURPRISED,
+  EMPATHIZE,
+  CHEERING;
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryReactionType.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryReactionType.java
@@ -1,8 +1,14 @@
 package com.heartsave.todaktodak_api.diary.constant;
 
 public enum DiaryReactionType {
-  LIKE,
-  SURPRISED,
-  EMPATHIZE,
-  CHEERING;
+  LIKE("like"),
+  SURPRISED("surprised"),
+  EMPATHIZE("empathize"),
+  CHEERING("cheering");
+
+  private final String reaction;
+
+  DiaryReactionType(String reaction) {
+    this.reaction = reaction;
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -3,6 +3,7 @@ package com.heartsave.todaktodak_api.diary.controller;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
+import com.heartsave.todaktodak_api.diary.dto.response.DiaryViewDetailResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryWriteResponse;
 import com.heartsave.todaktodak_api.diary.service.DiaryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PastOrPresent;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -94,5 +97,13 @@ public class DiaryController {
           @DateTimeFormat(pattern = "yyyy-MM")
           YearMonth yearMonth) {
     return ResponseEntity.status(HttpStatus.OK).body(diaryService.getIndex(principal, yearMonth));
+  }
+
+  @GetMapping("/detail")
+  public ResponseEntity<DiaryViewDetailResponse> getDiaryDetail(
+      @AuthenticationPrincipal TodakUser principal,
+      @Valid @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.") @RequestParam("date")
+          LocalDate requestDate) {
+    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(principal, requestDate));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -99,10 +99,26 @@ public class DiaryController {
     return ResponseEntity.status(HttpStatus.OK).body(diaryService.getIndex(principal, yearMonth));
   }
 
+  @Operation(summary = "일기 상세 조회")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "일기 상세 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "404", description = "해당 날짜의 일기를 찾을 수 없음")
+      })
   @GetMapping("/detail")
   public ResponseEntity<DiaryViewDetailResponse> getDiaryDetail(
       @AuthenticationPrincipal TodakUser principal,
-      @Valid @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.") @RequestParam("date")
+      @Parameter(
+              name = "date",
+              description = "조회할 일기의 날짜",
+              example = "2024-10-26",
+              required = true,
+              schema = @Schema(type = "string", format = "yyyy-MM-dd"))
+          @Valid
+          @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.")
+          @RequestParam("date")
+          @DateTimeFormat(pattern = "yyyy-MM-dd")
           LocalDate requestDate) {
     return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(principal, requestDate));
   }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -120,6 +120,7 @@ public class DiaryController {
           @RequestParam("date")
           @DateTimeFormat(pattern = "yyyy-MM-dd")
           LocalDate requestDate) {
-    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(principal, requestDate));
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(diaryService.getDetail(principal, requestDate));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryViewDetailResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryViewDetailResponse.java
@@ -1,0 +1,20 @@
+package com.heartsave.todaktodak_api.diary.dto.response;
+
+import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DiaryViewDetailResponse {
+  private Long diaryId;
+  private DiaryEmotion emotion;
+  private String content;
+  private String webtoonImageUrl;
+  private String bgmUrl;
+  private String aiComment;
+  private DiaryReactionCountProjection reactionCount;
+  private LocalDate date;
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryViewDetailResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryViewDetailResponse.java
@@ -2,19 +2,37 @@ package com.heartsave.todaktodak_api.diary.dto.response;
 
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
+@Schema(description = "일기 상세 조회 응답")
 @Getter
 @Builder
 public class DiaryViewDetailResponse {
+
+  @Schema(description = "일기 ID", example = "1")
   private Long diaryId;
+
+  @Schema(description = "일기에 기록된 감정", example = "HAPPY")
   private DiaryEmotion emotion;
+
+  @Schema(description = "일기 내용", example = "오늘은 정말 좋은 하루였다...")
   private String content;
+
+  @Schema(description = "웹툰 이미지 URL", example = "https://example.com/webtoon/123.jpg")
   private String webtoonImageUrl;
+
+  @Schema(description = "배경음악 URL", example = "https://example.com/music/123.mp3")
   private String bgmUrl;
+
+  @Schema(description = "AI가 작성한 코멘트", example = "오늘 하루도 수고 많으셨어요!")
   private String aiComment;
+
+  @Schema(description = "일기에 대한 반응 수 정보")
   private DiaryReactionCountProjection reactionCount;
+
+  @Schema(description = "일기 작성 날짜", example = "2024-10-26", type = "string", format = "date")
   private LocalDate date;
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
@@ -30,7 +30,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
@@ -87,7 +86,6 @@ public class DiaryEntity extends BaseEntity {
       cascade = CascadeType.ALL,
       orphanRemoval = true)
   @Builder.Default
-  @Setter
   private List<DiaryReactionEntity> reactions = new ArrayList<>();
 
   public void addAiContent(AiContentResponse response) {

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
@@ -7,6 +7,7 @@ import com.heartsave.todaktodak_api.ai.dto.AiContentResponse;
 import com.heartsave.todaktodak_api.common.entity.BaseEntity;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -17,15 +18,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 
@@ -76,7 +81,20 @@ public class DiaryEntity extends BaseEntity {
   @DateTimeFormat(iso = ISO.DATE_TIME)
   private LocalDateTime diaryCreatedTime;
 
+  @OneToMany(
+      fetch = FetchType.LAZY,
+      mappedBy = "diaryEntity",
+      cascade = CascadeType.ALL,
+      orphanRemoval = true)
+  @Builder.Default
+  @Setter
+  private List<DiaryReactionEntity> reactions = new ArrayList<>();
+
   public void addAiContent(AiContentResponse response) {
     this.aiComment = response.getAiComment();
+  }
+
+  public void addReaction(DiaryReactionEntity reactionType) {
+    reactions.add(reactionType);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryReactionEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryReactionEntity.java
@@ -1,0 +1,52 @@
+package com.heartsave.todaktodak_api.diary.entity;
+
+import com.heartsave.todaktodak_api.common.entity.BaseEntity;
+import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
+import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@SequenceGenerator(
+    name = "DIARY_REACTION_SEQ_GENERATOR",
+    sequenceName = "DIARY_REACTION_SEQ",
+    initialValue = 1,
+    allocationSize = 100)
+@Table(name = "diary_reaction")
+public class DiaryReactionEntity extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "DIARY_REACTION_SEQ_GENERATOR")
+  @Column(updatable = false)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity memberEntity;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "diary_id", nullable = false)
+  private DiaryEntity diaryEntity;
+
+  @Column(name = "reaction_type", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private DiaryReactionType reactionType;
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryReactionCountProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryReactionCountProjection.java
@@ -1,0 +1,11 @@
+package com.heartsave.todaktodak_api.diary.entity.projection;
+
+public interface DiaryReactionCountProjection {
+  Long getLike();
+
+  Long getSurprised();
+
+  Long getEmpathize();
+
+  Long getCheering();
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryReactionCountProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryReactionCountProjection.java
@@ -1,12 +1,14 @@
 package com.heartsave.todaktodak_api.diary.entity.projection;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 반응 수 정보")
 public interface DiaryReactionCountProjection {
 
   @Schema(description = "좋아요 수", example = "42")
-  Long getLike();
+  @JsonProperty("like")
+  Long getLikes();
 
   @Schema(description = "놀라워요 수", example = "15")
   Long getSurprised();

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryReactionCountProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryReactionCountProjection.java
@@ -1,11 +1,19 @@
 package com.heartsave.todaktodak_api.diary.entity.projection;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "일기 반응 수 정보")
 public interface DiaryReactionCountProjection {
+
+  @Schema(description = "좋아요 수", example = "42")
   Long getLike();
 
+  @Schema(description = "놀라워요 수", example = "15")
   Long getSurprised();
 
+  @Schema(description = "공감해요 수", example = "28")
   Long getEmpathize();
 
+  @Schema(description = "응원해요 수", example = "35")
   Long getCheering();
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryViewDetailProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryViewDetailProjection.java
@@ -1,0 +1,22 @@
+package com.heartsave.todaktodak_api.diary.entity.projection;
+
+import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
+import java.time.LocalDate;
+
+public interface DiaryViewDetailProjection {
+  Long getId();
+
+  DiaryEmotion getEmotion();
+
+  String getContent();
+
+  String getWebtoonImageUrl();
+
+  String getBgmUrl();
+
+  String getAiComment();
+
+  DiaryReactionCountProjection getReactionCount();
+
+  LocalDate getDiaryCreatedTime();
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryException.java
@@ -3,6 +3,7 @@ package com.heartsave.todaktodak_api.diary.exception;
 import com.heartsave.todaktodak_api.common.exception.BaseException;
 import com.heartsave.todaktodak_api.common.exception.ErrorFieldBuilder;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
+import java.time.LocalDate;
 import lombok.Getter;
 
 @Getter
@@ -16,5 +17,11 @@ public abstract class DiaryException extends BaseException {
 
   protected DiaryException(DiaryErrorSpec errorSpec, Long memberId) {
     super(errorSpec, ErrorFieldBuilder.builder().add("memberId", memberId).build());
+  }
+
+  protected DiaryException(DiaryErrorSpec errorSpec, Long memberId, LocalDate diaryDate) {
+    super(
+        errorSpec,
+        ErrorFieldBuilder.builder().add("memberId", memberId).add("diaryDate", diaryDate).build());
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryNotFoundException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.heartsave.todaktodak_api.diary.exception;
+
+import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
+import java.time.LocalDate;
+
+public class DiaryNotFoundException extends DiaryException {
+
+  public DiaryNotFoundException(DiaryErrorSpec errorSpec, Long memberId, LocalDate diaryDate) {
+    super(errorSpec, memberId, diaryDate);
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
@@ -1,0 +1,6 @@
+package com.heartsave.todaktodak_api.diary.repository;
+
+import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryReactionRepository extends JpaRepository<DiaryReactionEntity, Long> {}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -2,8 +2,11 @@ package com.heartsave.todaktodak_api.diary.repository;
 
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -27,8 +30,28 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
   @Query(
       value =
           "SELECT d.id as id, d.diaryCreatedTime as diaryCreatedTime FROM DiaryEntity d WHERE d.memberEntity.id = :memberId AND d.diaryCreatedTime BETWEEN :startDateTime AND :endDateTime ORDER BY d.diaryCreatedTime ASC")
-  List<DiaryIndexProjection> findIndexesByMemberIdAndDateTimes(
+  Optional<List<DiaryIndexProjection>> findIndexesByMemberIdAndDateTimes(
       @Param("memberId") Long memberId,
       @Param("startDateTime") LocalDateTime startDateTime,
       @Param("endDateTime") LocalDateTime endDateTime);
+
+  @Query(
+      value =
+          " SELECT d FROM DiaryEntity  d WHERE d.memberEntity.id = :memberId AND CAST (d.diaryCreatedTime as DATE) = :diaryDate ")
+  Optional<DiaryEntity> findByMemberIdAndDate(
+      @Param("memberId") Long memberId, @Param("diaryDate") LocalDate diaryDate);
+
+  @Query(
+      value =
+          """
+            SELECT
+              COUNT(CASE WHEN reaction_type = 'LIKE' THEN 1 END) as likes,
+              COUNT(CASE WHEN reaction_type = 'SURPRISED' THEN 1 END) as surprised,
+              COUNT(CASE WHEN reaction_type = 'EMPATHIZE' THEN 1 END) as empathize,
+              COUNT(CASE WHEN reaction_type = 'CHEERING' THEN 1 END) as cheering
+            FROM diary_reaction
+            WHERE diary_id = :diaryId
+            """,
+      nativeQuery = true)
+  Optional<DiaryReactionCountProjection> findReactionCountById(Long diaryId);
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -86,6 +86,7 @@ public class DiaryService {
 
   public DiaryViewDetailResponse getDiary(TodakUser principal, LocalDate requestDate) {
     Long memberId = principal.getId();
+    log.info("사용자의 나의 일기 정보를 요청합니다.");
     DiaryEntity diary =
         diaryRepository
             .findByMemberIdAndDate(memberId, requestDate)
@@ -95,6 +96,8 @@ public class DiaryService {
                         DiaryErrorSpec.DIARY_NOT_FOUND, memberId, requestDate));
     DiaryReactionCountProjection reactionCount =
         diaryRepository.findReactionCountById(diary.getId()).get();
+    log.info("사용자의 나의 일기 정보를 성공적으로 가져왔습니다.");
+
     return DiaryViewDetailResponse.builder()
         .diaryId(diary.getId())
         .emotion(diary.getEmotion())

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -84,7 +84,7 @@ public class DiaryService {
     return DiaryIndexResponse.builder().diaryIndexes(indexes).build();
   }
 
-  public DiaryViewDetailResponse getDiary(TodakUser principal, LocalDate requestDate) {
+  public DiaryViewDetailResponse getDetail(TodakUser principal, LocalDate requestDate) {
     Long memberId = principal.getId();
     log.info("사용자의 나의 일기 정보를 요청합니다.");
     DiaryEntity diary =

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -7,6 +7,7 @@ import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
+import com.heartsave.todaktodak_api.diary.dto.response.DiaryViewDetailResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryWriteResponse;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
@@ -16,6 +17,7 @@ import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
@@ -80,6 +82,10 @@ public class DiaryService {
             .orElseGet(List::of);
     log.info("해당 연월에 작성한 일기를 정보를 성공적으로 가져왔습니다.");
     return DiaryIndexResponse.builder().diaryIndexes(indexes).build();
+  }
+
+  public DiaryViewDetailResponse getDiary(TodakUser principal, LocalDate requestDate) {
+    return DiaryViewDetailResponse.builder().build();
   }
 
   private DiaryEntity createDiaryEntity(TodakUser principal, DiaryWriteRequest request) {

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -90,7 +90,9 @@ public class DiaryRepositoryTest {
     LocalDateTime testEnd = YearMonth.of(testYear, testMonth).atEndOfMonth().atTime(LocalTime.MAX);
 
     List<DiaryIndexProjection> resultIndex =
-        diaryRepository.findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd);
+        diaryRepository
+            .findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd)
+            .orElseGet(List::of);
     assertThat(resultIndex).as("메서드 응답이 null 입니다.").isNotNull();
 
     DiaryIndexProjection first = resultIndex.get(0);
@@ -125,7 +127,9 @@ public class DiaryRepositoryTest {
     LocalDateTime testEnd = YearMonth.of(testYear, testMonth).atEndOfMonth().atTime(LocalTime.MAX);
 
     List<DiaryIndexProjection> resultIndex =
-        diaryRepository.findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd);
+        diaryRepository
+            .findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd)
+            .orElseGet(List::of);
     assertThat(resultIndex).as("메서드 응답이 null 입니다.").isNotNull();
 
     assertThat(resultIndex.isEmpty()).as("메서드 응답 내부가 비어있지 않습니다.").isTrue();

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -3,10 +3,14 @@ package com.heartsave.todaktodak_api.diary.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
+import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
@@ -29,6 +33,8 @@ public class DiaryRepositoryTest {
 
   @Autowired private DiaryRepository diaryRepository;
   @Autowired private MemberRepository memberRepository;
+  @Autowired private DiaryReactionRepository diaryReactionRepository;
+
   private MemberEntity member;
   private DiaryEntity diary;
 
@@ -133,6 +139,147 @@ public class DiaryRepositoryTest {
     assertThat(resultIndex).as("메서드 응답이 null 입니다.").isNotNull();
 
     assertThat(resultIndex.isEmpty()).as("메서드 응답 내부가 비어있지 않습니다.").isTrue();
+  }
+
+  @Test
+  @DisplayName("findByMemberIdAndDate - 일기를 성공적으로 조회")
+  void findByMemberIdAndDateSuccess() {
+    LocalDate diaryDate = diary.getDiaryCreatedTime().toLocalDate();
+
+    Optional<DiaryEntity> result = diaryRepository.findByMemberIdAndDate(member.getId(), diaryDate);
+
+    assertThat(result).as("해당 날짜(%s)에 작성된 일기를 찾을 수 없습니다.", diaryDate).isPresent();
+    assertThat(result.get().getId())
+        .as(
+            "조회된 일기의 ID가 저장된 일기의 ID와 일치하지 않습니다. expected: %d, actual: %d",
+            diary.getId(), result.get().getId())
+        .isEqualTo(diary.getId());
+    assertThat(result.get().getMemberEntity().getId())
+        .as(
+            "조회된 일기의 작성자 ID가 예상한 작성자 ID와 일치하지 않습니다. expected: %d, actual: %d",
+            member.getId(), result.get().getMemberEntity().getId())
+        .isEqualTo(member.getId());
+    assertThat(result.get().getDiaryCreatedTime().toLocalDate())
+        .as(
+            "조회된 일기의 작성 날짜가 예상한 날짜와 일치하지 않습니다. expected: %s, actual: %s",
+            diaryDate, result.get().getDiaryCreatedTime().toLocalDate())
+        .isEqualTo(diaryDate);
+  }
+
+  @Test
+  @DisplayName("findByMemberIdAndDate - 해당 날짜에 일기가 없는 경우")
+  void findByMemberIdAndDateEmpty() {
+    LocalDate differentDate = diary.getDiaryCreatedTime().toLocalDate().plusDays(-1);
+
+    Optional<DiaryEntity> result =
+        diaryRepository.findByMemberIdAndDate(member.getId(), differentDate);
+
+    assertThat(result).as("존재하지 않아야 할 날짜(%s)에 일기가 조회되었습니다.", differentDate).isEmpty();
+  }
+
+  @Test
+  @DisplayName("findReactionCountById - 반응이 있는 경우 성공적으로 조회")
+  void findReactionCountByIdSuccess() {
+    // Given
+    Long expectedLikes = 1L;
+    Long expectedSurprised = 3L;
+    Long expectedEmpathize = 14L;
+    Long expectedCheering = 100L;
+
+    // LIKE 1개 생성
+    diaryReactionRepository.save(
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build());
+
+    // SURPRISED 3개 생성
+    for (int i = 0; i < expectedSurprised; i++) {
+      diaryReactionRepository.save(
+          DiaryReactionEntity.builder()
+              .memberEntity(member)
+              .diaryEntity(diary)
+              .reactionType(DiaryReactionType.SURPRISED)
+              .build());
+    }
+
+    // EMPATHIZE 14개 생성
+    for (int i = 0; i < expectedEmpathize; i++) {
+      diaryReactionRepository.save(
+          DiaryReactionEntity.builder()
+              .memberEntity(member)
+              .diaryEntity(diary)
+              .reactionType(DiaryReactionType.EMPATHIZE)
+              .build());
+    }
+
+    // CHEERING 100개 생성
+    for (int i = 0; i < expectedCheering; i++) {
+      diaryReactionRepository.save(
+          DiaryReactionEntity.builder()
+              .memberEntity(member)
+              .diaryEntity(diary)
+              .reactionType(DiaryReactionType.CHEERING)
+              .build());
+    }
+
+    Optional<DiaryReactionCountProjection> result =
+        diaryRepository.findReactionCountById(diary.getId());
+
+    assertThat(result).isPresent();
+    DiaryReactionCountProjection count = result.get();
+    assertThat(count.getLikes()).as("좋아요 수가 예상값과 다릅니다.").isEqualTo(expectedLikes);
+    assertThat(count.getSurprised()).as("놀라워요 수가 예상값과 다릅니다.").isEqualTo(expectedSurprised);
+    assertThat(count.getEmpathize()).as("공감해요 수가 예상값과 다릅니다.").isEqualTo(expectedEmpathize);
+    assertThat(count.getCheering()).as("응원해요 수가 예상값과 다릅니다.").isEqualTo(expectedCheering);
+  }
+
+  @Test
+  @DisplayName("findReactionCountById - 반응이 없는 경우")
+  void findReactionCountByIdEmpty() {
+    Optional<DiaryReactionCountProjection> result =
+        diaryRepository.findReactionCountById(diary.getId());
+
+    assertThat(result).isPresent();
+    DiaryReactionCountProjection count = result.get();
+    assertThat(count.getLikes()).as("좋아요 수가 0이 아닙니다.").isEqualTo(0L);
+    assertThat(count.getSurprised()).as("놀라워요 수가 0이 아닙니다.").isEqualTo(0L);
+    assertThat(count.getEmpathize()).as("공감해요 수가 0이 아닙니다.").isEqualTo(0L);
+    assertThat(count.getCheering()).as("응원해요 수가 0이 아닙니다.").isEqualTo(0L);
+  }
+
+  @Test
+  @DisplayName("findReactionCountById - 일기가 없는 경우")
+  void findReactionCountByIdWithNoDiary() {
+    DiaryReactionEntity reaction1 =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+    DiaryReactionEntity reaction2 =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.CHEERING)
+            .build();
+
+    diaryReactionRepository.save(reaction1);
+    diaryReactionRepository.save(reaction2);
+
+    diary.addReaction(reaction1);
+    diary.addReaction(reaction2);
+
+    diaryRepository.delete(diary);
+
+    Optional<DiaryReactionCountProjection> result =
+        diaryRepository.findReactionCountById(diary.getId());
+
+    assertThat(result.get().getLikes()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+    assertThat(result.get().getCheering()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+    assertThat(result.get().getEmpathize()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+    assertThat(result.get().getSurprised()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
   }
 
   @Test

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -31,7 +31,6 @@ import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -136,7 +135,7 @@ public class DiaryServiceTest {
 
     when(mockDiaryRepository.findIndexesByMemberIdAndDateTimes(
             principal.getId(), testStart, testEnd))
-        .thenReturn(testProjection);
+        .thenReturn(Optional.of(testProjection));
 
     DiaryIndexResponse indexes =
         diaryService.getIndex(principal, YearMonth.of(testYear, testMonth));
@@ -172,7 +171,7 @@ public class DiaryServiceTest {
 
     when(mockDiaryRepository.findIndexesByMemberIdAndDateTimes(
             principal.getId(), testStart, testEnd))
-        .thenReturn(new ArrayList<>());
+        .thenReturn(Optional.empty());
 
     DiaryIndexResponse indexes =
         diaryService.getIndex(principal, YearMonth.of(testYear, testMonth));

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -19,22 +19,26 @@ import com.heartsave.todaktodak_api.diary.common.TestDiaryObjectFactory;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
+import com.heartsave.todaktodak_api.diary.dto.response.DiaryViewDetailResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryWriteResponse;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import com.heartsave.todaktodak_api.diary.exception.DiaryDailyWritingLimitExceedException;
 import com.heartsave.todaktodak_api.diary.exception.DiaryDeleteNotFoundException;
 import com.heartsave.todaktodak_api.diary.exception.DiaryException;
+import com.heartsave.todaktodak_api.diary.exception.DiaryNotFoundException;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,13 +54,13 @@ public class DiaryServiceTest {
   @Mock private DiaryRepository mockDiaryRepository;
   @Mock private AiService mockAiService;
   @InjectMocks private DiaryService diaryService;
-  private static TodakUser principal;
-  private static MemberEntity member;
-  private static DiaryEntity diary;
-  private static final LocalDateTime FIXED_DATE = LocalDateTime.of(2024, 10, 21, 14, 14);
+  private TodakUser principal;
+  private MemberEntity member;
+  private DiaryEntity diary;
+  private final LocalDateTime NOW_DATE_TIME = LocalDateTime.now();
 
-  @BeforeAll
-  static void allSetup() {
+  @BeforeEach
+  void allSetup() {
     member = BaseTestEntity.createMember();
     diary = BaseTestEntity.createDiaryWithMember(member);
 
@@ -68,7 +72,7 @@ public class DiaryServiceTest {
   @DisplayName("일기 작성 성공")
   void diaryWritingSuccess() {
     DiaryWriteRequest request =
-        new DiaryWriteRequest(FIXED_DATE, DiaryEmotion.JOY, "test diary content");
+        new DiaryWriteRequest(NOW_DATE_TIME, DiaryEmotion.JOY, "test diary content");
     String AI_COMMENT = "this is test ai comment";
 
     when(mockMemberRepository.findById(anyLong())).thenReturn(Optional.of(member));
@@ -84,7 +88,7 @@ public class DiaryServiceTest {
   @DisplayName("하루 일기 작성 횟수 초과 에러 발생")
   void dailyDiaryWritingLimitException() {
     DiaryWriteRequest request =
-        new DiaryWriteRequest(FIXED_DATE, DiaryEmotion.JOY, "test diary content");
+        new DiaryWriteRequest(NOW_DATE_TIME, DiaryEmotion.JOY, "test diary content");
     when(mockMemberRepository.findById(anyLong())).thenReturn(Optional.of(member));
     when(mockDiaryRepository.existsByDate(anyLong(), any(LocalDateTime.class))).thenReturn(true);
 
@@ -180,5 +184,78 @@ public class DiaryServiceTest {
     System.out.println("responseIndexes = " + responseIndexes);
     assertThat(responseIndexes).as("응답이 null 입니다.").isNotNull();
     assertThat(responseIndexes.size()).as("응답 내용의 크기가 0이 아닙니다.").isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("일기 상세 조회 성공")
+  void getDiaryDetailSuccess() {
+    // given
+    LocalDate requestDate = NOW_DATE_TIME.toLocalDate();
+    DiaryReactionCountProjection mockReactionCount =
+        new DiaryReactionCountProjection() {
+          @Override
+          public Long getLikes() {
+            return 1L;
+          }
+
+          @Override
+          public Long getSurprised() {
+            return 2L;
+          }
+
+          @Override
+          public Long getEmpathize() {
+            return 3L;
+          }
+
+          @Override
+          public Long getCheering() {
+            return 4L;
+          }
+        };
+
+    when(mockDiaryRepository.findByMemberIdAndDate(anyLong(), any(LocalDate.class)))
+        .thenReturn(Optional.of(diary));
+    when(mockDiaryRepository.findReactionCountById(anyLong()))
+        .thenReturn(Optional.of(mockReactionCount));
+
+    DiaryViewDetailResponse response = diaryService.getDetail(principal, requestDate);
+
+    assertThat(response)
+        .satisfies(
+            r -> {
+              assertThat(r.getDiaryId()).isEqualTo(diary.getId());
+              assertThat(r.getEmotion()).isEqualTo(diary.getEmotion());
+              assertThat(r.getContent()).isEqualTo(diary.getContent());
+              assertThat(r.getWebtoonImageUrl()).isEqualTo(diary.getWebtoonImageUrl());
+              assertThat(r.getBgmUrl()).isEqualTo(diary.getBgmUrl());
+              assertThat(r.getAiComment()).isEqualTo(diary.getAiComment());
+              assertThat(r.getDate()).isEqualTo(diary.getDiaryCreatedTime().toLocalDate());
+
+              assertThat(r.getReactionCount().getLikes()).isEqualTo(1L);
+              assertThat(r.getReactionCount().getSurprised()).isEqualTo(2L);
+              assertThat(r.getReactionCount().getEmpathize()).isEqualTo(3L);
+              assertThat(r.getReactionCount().getCheering()).isEqualTo(4L);
+            });
+
+    verify(mockDiaryRepository, times(1)).findByMemberIdAndDate(anyLong(), any(LocalDate.class));
+    verify(mockDiaryRepository, times(1)).findReactionCountById(anyLong());
+  }
+
+  @Test
+  @DisplayName("일기 상세 조회 실패 - 일기를 찾을 수 없음")
+  void getDiaryDetailFail() {
+    LocalDate requestDate = NOW_DATE_TIME.toLocalDate();
+
+    when(mockDiaryRepository.findByMemberIdAndDate(anyLong(), any(LocalDate.class)))
+        .thenReturn(Optional.empty());
+
+    DiaryException diaryException =
+        assertThrows(
+            DiaryNotFoundException.class, () -> diaryService.getDetail(principal, requestDate));
+
+    assertThat(diaryException.getErrorSpec()).isEqualTo(DiaryErrorSpec.DIARY_NOT_FOUND);
+    verify(mockDiaryRepository, times(1)).findByMemberIdAndDate(anyLong(), any(LocalDate.class));
+    verify(mockDiaryRepository, times(0)).findReactionCountById(anyLong());
   }
 }


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항
- 나의 일기 상세 조회 API 추가
- 일기(DiaryEntity) 삭제시 반응(DiaryReactionEntity) 삭제 - cascading 설정

### 일기 상세 조회 쿼리
- 일기 상세 조회시 현재 쿼리를 2번 날립니다.
input : ```memberId``` 및 ```Date```
1. ```memberId```와 ```Date```에 해당하는 DiaryEntity를 요청합니다.
2. ```DiaryEntity```의 ID와 일치하는 ```Reaction```의 종류별 갯수를 요청합니다.
가져온 두 정보를 Response에 담아 전달합니다.

두 번의 쿼리보다는, 조금 복잡하지만 한 번의 쿼리를 날려 데이터를 얻는 것이 성능상 이점이라고 생각하여 1개로 하려 했으나,
JPQL에서는 From 절에 subQuery를 사용할 수 없었고, join을 하려면 성능상 이점을 얻기 위해 fetch join을 해야 하는 것으로 알고 있는데, 이에 대한 학습이 필요하기에 추가적인 시간이 필요하다 판단했습니다.
이 부분은 추후에 리팩토링 하겠습니다!


## 리뷰 받고 싶은 내용
 - 비즈니스 로직 중 놓친 부분이 없는지 확인 부탁드립니다!

## 테스트 및 결과
- 로컬 테스트 통과 확인했습니다!

## 관련 스크린샷 및 참고자료 (Optional)

close #45 