### PR TITLE
Feature/todak 164/public diary reaction

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryEmotion.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryEmotion.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.diary.constant;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 감정 상태")
@@ -11,5 +12,10 @@ public enum DiaryEmotion {
 
   DiaryEmotion(String emotion) {
     this.emotion = emotion;
+  }
+
+  @JsonValue
+  public String getEmotion() {
+    return emotion;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryReactionType.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/constant/DiaryReactionType.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.diary.constant;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 반응 타입")
@@ -20,5 +21,10 @@ public enum DiaryReactionType {
 
   DiaryReactionType(String reaction) {
     this.reaction = reaction;
+  }
+
+  @JsonValue
+  public String getReaction() {
+    return reaction;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
@@ -1,6 +1,7 @@
 package com.heartsave.todaktodak_api.diary.controller;
 
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.service.PublicDiaryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,6 +41,14 @@ public class PublicDiaryController {
     log.info("공개 일기 업로드 시작");
     publicDiaryService.write(principal, request.publicContent(), request.diaryId());
     log.info("공개 일기 업로드 성공");
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @PostMapping("/reaction")
+  public ResponseEntity<Void> toggleReaction(
+      @AuthenticationPrincipal TodakUser principal,
+      @Valid @RequestBody PublicDiaryReactionRequest request) {
+    publicDiaryService.toggleReactionStatus(principal, request);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
@@ -5,6 +5,8 @@ import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.service.PublicDiaryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,18 +39,30 @@ public class PublicDiaryController {
   @PostMapping
   public ResponseEntity<Void> writePublicContent(
       @AuthenticationPrincipal TodakUser principal,
-      @Valid @RequestBody PublicDiaryWriteRequest request) {
+      @Parameter(description = "일기 공개 업로드 요청 데이터", required = true) @Valid @RequestBody
+          PublicDiaryWriteRequest request) {
     log.info("공개 일기 업로드 시작");
     publicDiaryService.write(principal, request.publicContent(), request.diaryId());
     log.info("공개 일기 업로드 성공");
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
+  @Operation(
+      summary = "일기 반응 토글",
+      description = "공개 일기에 대한 반응(좋아요 등)을 토글합니다. 이미 있는 반응은 제거되고, 없는 반응은 추가됩니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "반응 토글 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+      })
   @PostMapping("/reaction")
   public ResponseEntity<Void> toggleReaction(
-      @AuthenticationPrincipal TodakUser principal, // Todo: 커스텀 에너테이션을 통해 TodakUser의 ID 바로 가져오기
-      @Valid @RequestBody PublicDiaryReactionRequest request) {
+      @Parameter(hidden = true) @AuthenticationPrincipal TodakUser principal,
+      @Parameter(description = "일기 반응 요청 데이터", required = true) @Valid @RequestBody
+          PublicDiaryReactionRequest request) {
+    log.info("일기장 반응 토글을 요청합니다");
     publicDiaryService.toggleReactionStatus(principal, request);
+    log.info("일기장 반응 토글을 성공적으로 마쳤습니다.");
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
@@ -46,7 +46,7 @@ public class PublicDiaryController {
 
   @PostMapping("/reaction")
   public ResponseEntity<Void> toggleReaction(
-      @AuthenticationPrincipal TodakUser principal,
+      @AuthenticationPrincipal TodakUser principal, // Todo: 커스텀 에너테이션을 통해 TodakUser의 ID 바로 가져오기
       @Valid @RequestBody PublicDiaryReactionRequest request) {
     publicDiaryService.toggleReactionStatus(principal, request);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/PublicDiaryReactionRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/PublicDiaryReactionRequest.java
@@ -1,8 +1,12 @@
 package com.heartsave.todaktodak_api.diary.dto.request;
 
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "공개 일기 반응 요청 데이터")
 public record PublicDiaryReactionRequest(
-    @Min(1L) Long diaryId, @NotBlank DiaryReactionType reactionType) {}
+    @Schema(description = "일기 ID", example = "1", minimum = "1") @Min(1L) Long diaryId,
+    @Schema(description = "반응 타입", example = "LIKE", required = true) @NotNull
+        DiaryReactionType reactionType) {}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/PublicDiaryReactionRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/PublicDiaryReactionRequest.java
@@ -1,0 +1,8 @@
+package com.heartsave.todaktodak_api.diary.dto.request;
+
+import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record PublicDiaryReactionRequest(
+    @Min(1L) Long diaryId, @NotBlank DiaryReactionType reactionType) {}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
@@ -96,6 +96,10 @@ public class DiaryEntity extends BaseEntity {
       orphanRemoval = true)
   private PublicDiaryEntity publicDiaryEntity;
 
+  public static DiaryEntity createById(Long id) {
+    return DiaryEntity.builder().id(id).build();
+  }
+
   public void addAiContent(AiContentResponse response) {
     this.aiComment = response.getAiComment();
   }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
@@ -84,8 +84,10 @@ public class DiaryEntity extends BaseEntity {
   @OneToMany(
       fetch = FetchType.LAZY,
       mappedBy = "diaryEntity",
-      cascade = CascadeType.ALL,
-      orphanRemoval = true)
+      cascade =
+          CascadeType
+              .ALL, // 현재는 JPA Level의 cascade -> Diary 삭제시, ReactionEntity에 대한 Del Query가 별도로 나간다.
+      orphanRemoval = true) // Todo : DB Level의 cascade를 설정하여 Diary Del Query 하나만 날려 cascade를 적용하자.
   @Builder.Default
   private List<DiaryReactionEntity> reactions = new ArrayList<>();
 

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryReactionEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryReactionEntity.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,7 +32,13 @@ import lombok.NoArgsConstructor;
     sequenceName = "DIARY_REACTION_SEQ",
     initialValue = 1,
     allocationSize = 100)
-@Table(name = "diary_reaction")
+@Table(
+    name = "diary_reaction",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          columnNames = {"member_id", "diary_id", "reaction_type"},
+          name = "uk_member_diary_reaction")
+    })
 public class DiaryReactionEntity extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "DIARY_REACTION_SEQ_GENERATOR")

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
@@ -14,22 +14,22 @@ public interface DiaryReactionRepository extends JpaRepository<DiaryReactionEnti
   @Query(
       value =
           """
-                    SELECT
-                      COUNT(CASE WHEN reaction_type = 'LIKE' THEN 1 END) as likes,
-                      COUNT(CASE WHEN reaction_type = 'SURPRISED' THEN 1 END) as surprised,
-                      COUNT(CASE WHEN reaction_type = 'EMPATHIZE' THEN 1 END) as empathize,
-                      COUNT(CASE WHEN reaction_type = 'CHEERING' THEN 1 END) as cheering
-                    FROM diary_reaction
-                    WHERE diary_id = :diaryId
-                    """,
+            SELECT
+              COUNT(CASE WHEN reaction_type = 'LIKE' THEN 1 END) as likes,
+              COUNT(CASE WHEN reaction_type = 'SURPRISED' THEN 1 END) as surprised,
+              COUNT(CASE WHEN reaction_type = 'EMPATHIZE' THEN 1 END) as empathize,
+              COUNT(CASE WHEN reaction_type = 'CHEERING' THEN 1 END) as cheering
+            FROM diary_reaction
+            WHERE diary_id = :diaryId
+          """,
       nativeQuery = true)
-  Optional<DiaryReactionCountProjection> countByDiaryId(Long diaryId);
+  Optional<DiaryReactionCountProjection> countEachByDiaryId(Long diaryId);
 
   @Modifying
   @Query(
       """
         DELETE FROM DiaryReactionEntity  dr WHERE dr.memberEntity.id = :memberId AND dr.diaryEntity.id = :diaryId AND dr.reactionType = :reactionType
-    """)
+      """)
   int deleteByMemberIdAndDiaryIdAndReactionType(
       @Param("memberId") Long memberId,
       @Param("diaryId") Long diaryId,

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
@@ -1,6 +1,21 @@
 package com.heartsave.todaktodak_api.diary.repository;
 
+import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface DiaryReactionRepository extends JpaRepository<DiaryReactionEntity, Long> {}
+public interface DiaryReactionRepository extends JpaRepository<DiaryReactionEntity, Long> {
+
+  @Modifying
+  @Query(
+      """
+        DELETE FROM DiaryReactionEntity  dr WHERE dr.memberEntity.id = :memberId AND dr.diaryEntity.id = :diaryId AND dr.reactionType = :reactionType
+    """)
+  int deleteByMemberIdAndDiaryIdAndReactionType(
+      @Param("memberId") Long memberId,
+      @Param("diaryId") Long diaryId,
+      @Param("reactionType") DiaryReactionType reactionType);
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepository.java
@@ -2,12 +2,28 @@ package com.heartsave.todaktodak_api.diary.repository;
 
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface DiaryReactionRepository extends JpaRepository<DiaryReactionEntity, Long> {
+
+  @Query(
+      value =
+          """
+                    SELECT
+                      COUNT(CASE WHEN reaction_type = 'LIKE' THEN 1 END) as likes,
+                      COUNT(CASE WHEN reaction_type = 'SURPRISED' THEN 1 END) as surprised,
+                      COUNT(CASE WHEN reaction_type = 'EMPATHIZE' THEN 1 END) as empathize,
+                      COUNT(CASE WHEN reaction_type = 'CHEERING' THEN 1 END) as cheering
+                    FROM diary_reaction
+                    WHERE diary_id = :diaryId
+                    """,
+      nativeQuery = true)
+  Optional<DiaryReactionCountProjection> countByDiaryId(Long diaryId);
 
   @Modifying
   @Query(

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -2,7 +2,6 @@ package com.heartsave.todaktodak_api.diary.repository;
 
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,18 +39,4 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
           " SELECT d FROM DiaryEntity  d WHERE d.memberEntity.id = :memberId AND CAST (d.diaryCreatedTime as DATE) = :diaryDate ")
   Optional<DiaryEntity> findByMemberIdAndDate(
       @Param("memberId") Long memberId, @Param("diaryDate") LocalDate diaryDate);
-
-  @Query(
-      value =
-          """
-            SELECT
-              COUNT(CASE WHEN reaction_type = 'LIKE' THEN 1 END) as likes,
-              COUNT(CASE WHEN reaction_type = 'SURPRISED' THEN 1 END) as surprised,
-              COUNT(CASE WHEN reaction_type = 'EMPATHIZE' THEN 1 END) as empathize,
-              COUNT(CASE WHEN reaction_type = 'CHEERING' THEN 1 END) as cheering
-            FROM diary_reaction
-            WHERE diary_id = :diaryId
-            """,
-      nativeQuery = true)
-  Optional<DiaryReactionCountProjection> findReactionCountById(Long diaryId);
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -97,7 +97,7 @@ public class DiaryService {
                     new DiaryNotFoundException(
                         DiaryErrorSpec.DIARY_NOT_FOUND, memberId, requestDate));
     DiaryReactionCountProjection reactionCount =
-        diaryReactionRepository.countByDiaryId(diary.getId()).get();
+        diaryReactionRepository.countEachByDiaryId(diary.getId()).get();
     log.info("사용자의 나의 일기 정보를 성공적으로 가져왔습니다.");
 
     return DiaryViewDetailResponse.builder()

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -15,6 +15,7 @@ import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountPr
 import com.heartsave.todaktodak_api.diary.exception.DiaryDailyWritingLimitExceedException;
 import com.heartsave.todaktodak_api.diary.exception.DiaryDeleteNotFoundException;
 import com.heartsave.todaktodak_api.diary.exception.DiaryNotFoundException;
+import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
@@ -37,6 +38,7 @@ public class DiaryService {
 
   private final AiService aiService;
   private final DiaryRepository diaryRepository;
+  private final DiaryReactionRepository diaryReactionRepository;
   private final MemberRepository memberRepository;
 
   public DiaryWriteResponse write(TodakUser principal, DiaryWriteRequest request) {
@@ -95,7 +97,7 @@ public class DiaryService {
                     new DiaryNotFoundException(
                         DiaryErrorSpec.DIARY_NOT_FOUND, memberId, requestDate));
     DiaryReactionCountProjection reactionCount =
-        diaryRepository.findReactionCountById(diary.getId()).get();
+        diaryReactionRepository.countByDiaryId(diary.getId()).get();
     log.info("사용자의 나의 일기 정보를 성공적으로 가져왔습니다.");
 
     return DiaryViewDetailResponse.builder()

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
@@ -2,9 +2,11 @@ package com.heartsave.todaktodak_api.diary.service;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
 import com.heartsave.todaktodak_api.diary.exception.DiaryNotFoundException;
+import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.diary.repository.PublicDiaryRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class PublicDiaryService {
   private final DiaryRepository diaryRepository;
   private final PublicDiaryRepository publicDiaryRepository;
+  private final DiaryReactionRepository diaryReactionRepository;
 
   public void write(TodakUser principal, String publicContent, Long diaryId) {
     Long memberId = principal.getId();
     DiaryEntity diary =
         diaryRepository
-            .findById(diaryId)
+            .findById(diaryId) // Todo : exist 로 최적화
             .orElseThrow(
                 () ->
                     new DiaryNotFoundException(DiaryErrorSpec.DIARY_NOT_FOUND, memberId, diaryId));
@@ -36,4 +39,6 @@ public class PublicDiaryService {
             .build();
     publicDiaryRepository.save(publicDiary);
   }
+
+  public void toggleReactionStatus(TodakUser principal, PublicDiaryReactionRequest request) {}
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
@@ -48,4 +48,8 @@ public class MemberEntity extends BaseEntity {
   private TodakRole role;
 
   private Integer characterSeed;
+
+  public static MemberEntity createById(Long id) {
+    return MemberEntity.builder().id(id).build();
+  }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
@@ -200,7 +200,7 @@ public class DiaryControllerTest {
     MockHttpServletResponse response = mvcResult.getResponse();
     response.setCharacterEncoding("utf-8");
     String contentAsString = response.getContentAsString();
-    assertThat(contentAsString).contains("테스트 일기 내용").contains("JOY");
+    assertThat(contentAsString).contains("테스트 일기 내용").contains("joy");
   }
 
   @Test

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.WithMockTodakUser;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
+import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.service.PublicDiaryService;
 import org.junit.jupiter.api.DisplayName;
@@ -68,6 +70,73 @@ public class PublicDiaryControllerTest {
             post("/api/v1/diary/public")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("정상적인 반응 토글 요청 시 성공")
+  @WithMockTodakUser
+  void toggleReaction_Success() throws Exception {
+    Long diaryId = 1L;
+    DiaryReactionType reactionType = DiaryReactionType.LIKE;
+    PublicDiaryReactionRequest request = new PublicDiaryReactionRequest(diaryId, reactionType);
+
+    doNothing()
+        .when(publicDiaryService)
+        .toggleReactionStatus(any(TodakUser.class), any(PublicDiaryReactionRequest.class));
+
+    mockMvc
+        .perform(
+            post("/api/v1/diary/public/reaction")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("반응 토글 실패 - 잘못된 일기 ID")
+  @WithMockTodakUser
+  void toggleReaction_Fail_InvalidDiaryId() throws Exception {
+    Long invalidDiaryId = 0L;
+    DiaryReactionType reactionType = DiaryReactionType.LIKE;
+    PublicDiaryReactionRequest request =
+        new PublicDiaryReactionRequest(invalidDiaryId, reactionType);
+
+    mockMvc
+        .perform(
+            post("/api/v1/diary/public/reaction")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("반응 토글 실패 - 반응 타입이 null")
+  @WithMockTodakUser
+  void toggleReaction_Fail_NullReactionType() throws Exception {
+    Long diaryId = 1L;
+    DiaryReactionType reactionType = null;
+    PublicDiaryReactionRequest request = new PublicDiaryReactionRequest(diaryId, reactionType);
+
+    mockMvc
+        .perform(
+            post("/api/v1/diary/public/reaction")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("반응 토글 실패 - 잘못된 요청 형식")
+  @WithMockTodakUser
+  void toggleReaction_Fail_InvalidRequestFormat() throws Exception {
+    String invalidRequest = "{\"diaryId\": \"invalid\", \"reactionType\": \"like\"}";
+
+    mockMvc
+        .perform(
+            post("/api/v1/diary/public/reaction")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidRequest))
         .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepositoryTest.java
@@ -1,0 +1,264 @@
+package com.heartsave.todaktodak_api.diary.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
+import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
+import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
+import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@Slf4j
+@DataJpaTest
+public class DiaryReactionRepositoryTest {
+
+  @Autowired private DiaryReactionRepository diaryReactionRepository;
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private DiaryRepository diaryRepository;
+  @Autowired private TestEntityManager tem;
+
+  private MemberEntity member;
+  private DiaryEntity diary;
+
+  @BeforeEach
+  void setupAll() {
+    member = BaseTestEntity.createMemberNoId();
+    diary = BaseTestEntity.createDiaryNoIdWithMember(member);
+    memberRepository.save(member);
+    diaryRepository.save(diary);
+  }
+
+  @Test
+  @DisplayName("findReactionCountById - 반응이 있는 경우 성공적으로 조회")
+  void findReactionCountByIdSuccess() {
+    Long expectedLikes = 1L;
+    Long expectedSurprised = 3L;
+    Long expectedEmpathize = 14L;
+    Long expectedCheering = 100L;
+    MemberEntity testMember = BaseTestEntity.createMemberNoId();
+    memberRepository.save(testMember);
+    // LIKE 1개 생성
+    diaryReactionRepository.save(
+        DiaryReactionEntity.builder()
+            .memberEntity(testMember)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build());
+
+    // SURPRISED 3개 생성
+    for (int i = 0; i < expectedSurprised; i++) {
+      testMember = BaseTestEntity.createMemberNoId();
+      memberRepository.save(testMember);
+      diaryReactionRepository.save(
+          DiaryReactionEntity.builder()
+              .memberEntity(testMember)
+              .diaryEntity(diary)
+              .reactionType(DiaryReactionType.SURPRISED)
+              .build());
+    }
+
+    // EMPATHIZE 14개 생성
+    for (int i = 0; i < expectedEmpathize; i++) {
+      testMember = BaseTestEntity.createMemberNoId();
+      memberRepository.save(testMember);
+      diaryReactionRepository.save(
+          DiaryReactionEntity.builder()
+              .memberEntity(testMember)
+              .diaryEntity(diary)
+              .reactionType(DiaryReactionType.EMPATHIZE)
+              .build());
+    }
+
+    // CHEERING 100개 생성
+    for (int i = 0; i < expectedCheering; i++) {
+      testMember = BaseTestEntity.createMemberNoId();
+      memberRepository.save(testMember);
+      diaryReactionRepository.save(
+          DiaryReactionEntity.builder()
+              .memberEntity(testMember)
+              .diaryEntity(diary)
+              .reactionType(DiaryReactionType.CHEERING)
+              .build());
+    }
+
+    Optional<DiaryReactionCountProjection> result =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+
+    assertThat(result).isPresent();
+    DiaryReactionCountProjection count = result.get();
+    assertThat(count.getLikes()).as("좋아요 수가 예상값과 다릅니다.").isEqualTo(expectedLikes);
+    assertThat(count.getSurprised()).as("놀라워요 수가 예상값과 다릅니다.").isEqualTo(expectedSurprised);
+    assertThat(count.getEmpathize()).as("공감해요 수가 예상값과 다릅니다.").isEqualTo(expectedEmpathize);
+    assertThat(count.getCheering()).as("응원해요 수가 예상값과 다릅니다.").isEqualTo(expectedCheering);
+  }
+
+  @Test
+  @DisplayName("findReactionCountById - 반응이 없는 경우")
+  void findReactionCountByIdEmpty() {
+    Optional<DiaryReactionCountProjection> result =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+
+    assertThat(result).isPresent();
+    DiaryReactionCountProjection count = result.get();
+    assertThat(count.getLikes()).as("좋아요 수가 0이 아닙니다.").isEqualTo(0L);
+    assertThat(count.getSurprised()).as("놀라워요 수가 0이 아닙니다.").isEqualTo(0L);
+    assertThat(count.getEmpathize()).as("공감해요 수가 0이 아닙니다.").isEqualTo(0L);
+    assertThat(count.getCheering()).as("응원해요 수가 0이 아닙니다.").isEqualTo(0L);
+  }
+
+  @Test
+  @DisplayName("findReactionCountById - 일기가 없는 경우")
+  void findReactionCountByIdWithNoDiary() {
+    DiaryReactionEntity reaction1 =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+    DiaryReactionEntity reaction2 =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.CHEERING)
+            .build();
+
+    diaryReactionRepository.save(reaction1);
+    diaryReactionRepository.save(reaction2);
+
+    diary.addReaction(reaction1);
+    diary.addReaction(reaction2);
+
+    diaryRepository.delete(diary);
+
+    Optional<DiaryReactionCountProjection> result =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+
+    assertThat(result.get().getLikes()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+    assertThat(result.get().getCheering()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+    assertThat(result.get().getEmpathize()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+    assertThat(result.get().getSurprised()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("toggleReactionStatus - 같은 멤버가 같은 일기에 같은 타입의 반응을 하면 삭제됨")
+  void toggleReactionStatusTest() {
+    DiaryReactionEntity reaction =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+
+    diaryReactionRepository.save(reaction);
+
+    Optional<DiaryReactionCountProjection> resultAfterSave =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+    assertThat(resultAfterSave.get().getLikes()).as("반응이 저장되지 않았습니다.").isEqualTo(1);
+
+    diaryReactionRepository.deleteByMemberIdAndDiaryIdAndReactionType(
+        member.getId(), diary.getId(), DiaryReactionType.LIKE);
+
+    Optional<DiaryReactionCountProjection> resultAfterDelete =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+    assertThat(resultAfterDelete.get().getLikes()).as("반응이 삭제되지 않았습니다.").isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("toggleReactionStatus - 같은 멤버가 같은 일기에 다른 타입의 반응을 하면 모두 저장됨")
+  void toggleDifferentReactionTypeTest() {
+    DiaryReactionEntity likeReaction =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+
+    DiaryReactionEntity cheeringReaction =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.CHEERING)
+            .build();
+
+    diaryReactionRepository.save(likeReaction);
+    diaryReactionRepository.save(cheeringReaction);
+
+    Optional<DiaryReactionCountProjection> result =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+    assertThat(result.get().getLikes()).as("LIKE 반응이 저장되지 않았습니다.").isEqualTo(1);
+    assertThat(result.get().getCheering()).as("CHEERING 반응이 저장되지 않았습니다.").isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("toggleReactionStatus - 다른 멤버가 같은 일기에 같은 타입의 반응을 하면 모두 저장됨")
+  void toggleSameReactionTypeDifferentMemberTest() {
+    MemberEntity anotherMember = BaseTestEntity.createMemberNoId();
+    memberRepository.save(anotherMember);
+
+    DiaryReactionEntity reaction1 =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+
+    DiaryReactionEntity reaction2 =
+        DiaryReactionEntity.builder()
+            .memberEntity(anotherMember)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+
+    diaryReactionRepository.save(reaction1);
+    diaryReactionRepository.save(reaction2);
+
+    Optional<DiaryReactionCountProjection> result =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+    assertThat(result.get().getLikes()).as("두 멤버의 LIKE 반응이 모두 저장되지 않았습니다.").isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("toggleReactionStatus - 같은 멤버가 같은 일기에 같은 타입의 반응을 중복 저장할 경우 예외 발생")
+  void toggleReactionStatusDuplicateTest() {
+    DiaryReactionEntity reaction =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+    diary.addReaction(reaction);
+
+    DiaryReactionEntity duplicateReaction =
+        DiaryReactionEntity.builder()
+            .memberEntity(member)
+            .diaryEntity(diary)
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+    tem.flush();
+
+    assertThatThrownBy(
+            () -> {
+              diaryReactionRepository.save(duplicateReaction);
+              tem.flush();
+            },
+            "제약조건 위반 예외가 발생해야 합니다.")
+        .isInstanceOf(ConstraintViolationException.class);
+    tem.clear(); // duplicateReaction clear
+    Optional<DiaryReactionCountProjection> result =
+        diaryReactionRepository.countEachByDiaryId(diary.getId());
+    Assertions.assertThat(result.get().getLikes()).as("기존 반응이 유지되어야 합니다.").isEqualTo(1);
+  }
+}

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -3,11 +3,8 @@ package com.heartsave.todaktodak_api.diary.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.heartsave.todaktodak_api.common.BaseTestEntity;
-import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
-import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.time.LocalDate;
@@ -33,13 +30,12 @@ public class DiaryRepositoryTest {
 
   @Autowired private DiaryRepository diaryRepository;
   @Autowired private MemberRepository memberRepository;
-  @Autowired private DiaryReactionRepository diaryReactionRepository;
 
   private MemberEntity member;
   private DiaryEntity diary;
 
   @BeforeEach
-  void setupAll() {
+  void setup() {
     member = BaseTestEntity.createMemberNoId();
     diary = BaseTestEntity.createDiaryNoIdWithMember(member);
     memberRepository.save(member);
@@ -175,118 +171,6 @@ public class DiaryRepositoryTest {
         diaryRepository.findByMemberIdAndDate(member.getId(), differentDate);
 
     assertThat(result).as("존재하지 않아야 할 날짜(%s)에 일기가 조회되었습니다.", differentDate).isEmpty();
-  }
-
-  @Test
-  @DisplayName("findReactionCountById - 반응이 있는 경우 성공적으로 조회")
-  void findReactionCountByIdSuccess() {
-    // Given
-    Long expectedLikes = 1L;
-    Long expectedSurprised = 3L;
-    Long expectedEmpathize = 14L;
-    Long expectedCheering = 100L;
-    MemberEntity testMember = BaseTestEntity.createMemberNoId();
-    memberRepository.save(testMember);
-    // LIKE 1개 생성
-    diaryReactionRepository.save(
-        DiaryReactionEntity.builder()
-            .memberEntity(testMember)
-            .diaryEntity(diary)
-            .reactionType(DiaryReactionType.LIKE)
-            .build());
-
-    // SURPRISED 3개 생성
-    for (int i = 0; i < expectedSurprised; i++) {
-      testMember = BaseTestEntity.createMemberNoId();
-      memberRepository.save(testMember);
-      diaryReactionRepository.save(
-          DiaryReactionEntity.builder()
-              .memberEntity(testMember)
-              .diaryEntity(diary)
-              .reactionType(DiaryReactionType.SURPRISED)
-              .build());
-    }
-
-    // EMPATHIZE 14개 생성
-    for (int i = 0; i < expectedEmpathize; i++) {
-      testMember = BaseTestEntity.createMemberNoId();
-      memberRepository.save(testMember);
-      diaryReactionRepository.save(
-          DiaryReactionEntity.builder()
-              .memberEntity(testMember)
-              .diaryEntity(diary)
-              .reactionType(DiaryReactionType.EMPATHIZE)
-              .build());
-    }
-
-    // CHEERING 100개 생성
-    for (int i = 0; i < expectedCheering; i++) {
-      testMember = BaseTestEntity.createMemberNoId();
-      memberRepository.save(testMember);
-      diaryReactionRepository.save(
-          DiaryReactionEntity.builder()
-              .memberEntity(testMember)
-              .diaryEntity(diary)
-              .reactionType(DiaryReactionType.CHEERING)
-              .build());
-    }
-
-    Optional<DiaryReactionCountProjection> result =
-        diaryReactionRepository.countByDiaryId(diary.getId());
-
-    assertThat(result).isPresent();
-    DiaryReactionCountProjection count = result.get();
-    assertThat(count.getLikes()).as("좋아요 수가 예상값과 다릅니다.").isEqualTo(expectedLikes);
-    assertThat(count.getSurprised()).as("놀라워요 수가 예상값과 다릅니다.").isEqualTo(expectedSurprised);
-    assertThat(count.getEmpathize()).as("공감해요 수가 예상값과 다릅니다.").isEqualTo(expectedEmpathize);
-    assertThat(count.getCheering()).as("응원해요 수가 예상값과 다릅니다.").isEqualTo(expectedCheering);
-  }
-
-  @Test
-  @DisplayName("findReactionCountById - 반응이 없는 경우")
-  void findReactionCountByIdEmpty() {
-    Optional<DiaryReactionCountProjection> result =
-        diaryReactionRepository.countByDiaryId(diary.getId());
-
-    assertThat(result).isPresent();
-    DiaryReactionCountProjection count = result.get();
-    assertThat(count.getLikes()).as("좋아요 수가 0이 아닙니다.").isEqualTo(0L);
-    assertThat(count.getSurprised()).as("놀라워요 수가 0이 아닙니다.").isEqualTo(0L);
-    assertThat(count.getEmpathize()).as("공감해요 수가 0이 아닙니다.").isEqualTo(0L);
-    assertThat(count.getCheering()).as("응원해요 수가 0이 아닙니다.").isEqualTo(0L);
-  }
-
-  @Test
-  @DisplayName("findReactionCountById - 일기가 없는 경우")
-  void findReactionCountByIdWithNoDiary() {
-    DiaryReactionEntity reaction1 =
-        DiaryReactionEntity.builder()
-            .memberEntity(member)
-            .diaryEntity(diary)
-            .reactionType(DiaryReactionType.LIKE)
-            .build();
-    DiaryReactionEntity reaction2 =
-        DiaryReactionEntity.builder()
-            .memberEntity(member)
-            .diaryEntity(diary)
-            .reactionType(DiaryReactionType.CHEERING)
-            .build();
-
-    diaryReactionRepository.save(reaction1);
-    diaryReactionRepository.save(reaction2);
-
-    diary.addReaction(reaction1);
-    diary.addReaction(reaction2);
-
-    diaryRepository.delete(diary);
-
-    Optional<DiaryReactionCountProjection> result =
-        diaryReactionRepository.countByDiaryId(diary.getId());
-
-    assertThat(result.get().getLikes()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
-    assertThat(result.get().getCheering()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
-    assertThat(result.get().getEmpathize()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
-    assertThat(result.get().getSurprised()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
   }
 
   @Test

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -185,20 +185,23 @@ public class DiaryRepositoryTest {
     Long expectedSurprised = 3L;
     Long expectedEmpathize = 14L;
     Long expectedCheering = 100L;
-
+    MemberEntity testMember = BaseTestEntity.createMemberNoId();
+    memberRepository.save(testMember);
     // LIKE 1개 생성
     diaryReactionRepository.save(
         DiaryReactionEntity.builder()
-            .memberEntity(member)
+            .memberEntity(testMember)
             .diaryEntity(diary)
             .reactionType(DiaryReactionType.LIKE)
             .build());
 
     // SURPRISED 3개 생성
     for (int i = 0; i < expectedSurprised; i++) {
+      testMember = BaseTestEntity.createMemberNoId();
+      memberRepository.save(testMember);
       diaryReactionRepository.save(
           DiaryReactionEntity.builder()
-              .memberEntity(member)
+              .memberEntity(testMember)
               .diaryEntity(diary)
               .reactionType(DiaryReactionType.SURPRISED)
               .build());
@@ -206,9 +209,11 @@ public class DiaryRepositoryTest {
 
     // EMPATHIZE 14개 생성
     for (int i = 0; i < expectedEmpathize; i++) {
+      testMember = BaseTestEntity.createMemberNoId();
+      memberRepository.save(testMember);
       diaryReactionRepository.save(
           DiaryReactionEntity.builder()
-              .memberEntity(member)
+              .memberEntity(testMember)
               .diaryEntity(diary)
               .reactionType(DiaryReactionType.EMPATHIZE)
               .build());
@@ -216,9 +221,11 @@ public class DiaryRepositoryTest {
 
     // CHEERING 100개 생성
     for (int i = 0; i < expectedCheering; i++) {
+      testMember = BaseTestEntity.createMemberNoId();
+      memberRepository.save(testMember);
       diaryReactionRepository.save(
           DiaryReactionEntity.builder()
-              .memberEntity(member)
+              .memberEntity(testMember)
               .diaryEntity(diary)
               .reactionType(DiaryReactionType.CHEERING)
               .build());

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -232,7 +232,7 @@ public class DiaryRepositoryTest {
     }
 
     Optional<DiaryReactionCountProjection> result =
-        diaryRepository.findReactionCountById(diary.getId());
+        diaryReactionRepository.countByDiaryId(diary.getId());
 
     assertThat(result).isPresent();
     DiaryReactionCountProjection count = result.get();
@@ -246,7 +246,7 @@ public class DiaryRepositoryTest {
   @DisplayName("findReactionCountById - 반응이 없는 경우")
   void findReactionCountByIdEmpty() {
     Optional<DiaryReactionCountProjection> result =
-        diaryRepository.findReactionCountById(diary.getId());
+        diaryReactionRepository.countByDiaryId(diary.getId());
 
     assertThat(result).isPresent();
     DiaryReactionCountProjection count = result.get();
@@ -281,7 +281,7 @@ public class DiaryRepositoryTest {
     diaryRepository.delete(diary);
 
     Optional<DiaryReactionCountProjection> result =
-        diaryRepository.findReactionCountById(diary.getId());
+        diaryReactionRepository.countByDiaryId(diary.getId());
 
     assertThat(result.get().getLikes()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
     assertThat(result.get().getCheering()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -28,6 +28,7 @@ import com.heartsave.todaktodak_api.diary.exception.DiaryDailyWritingLimitExceed
 import com.heartsave.todaktodak_api.diary.exception.DiaryDeleteNotFoundException;
 import com.heartsave.todaktodak_api.diary.exception.DiaryException;
 import com.heartsave.todaktodak_api.diary.exception.DiaryNotFoundException;
+import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
@@ -52,6 +53,7 @@ public class DiaryServiceTest {
 
   @Mock private MemberRepository mockMemberRepository;
   @Mock private DiaryRepository mockDiaryRepository;
+  @Mock private DiaryReactionRepository mockDiaryReactionRepository;
   @Mock private AiService mockAiService;
   @InjectMocks private DiaryService diaryService;
   private TodakUser principal;
@@ -216,7 +218,7 @@ public class DiaryServiceTest {
 
     when(mockDiaryRepository.findByMemberIdAndDate(anyLong(), any(LocalDate.class)))
         .thenReturn(Optional.of(diary));
-    when(mockDiaryRepository.findReactionCountById(anyLong()))
+    when(mockDiaryReactionRepository.countByDiaryId(anyLong()))
         .thenReturn(Optional.of(mockReactionCount));
 
     DiaryViewDetailResponse response = diaryService.getDetail(principal, requestDate);
@@ -239,7 +241,7 @@ public class DiaryServiceTest {
             });
 
     verify(mockDiaryRepository, times(1)).findByMemberIdAndDate(anyLong(), any(LocalDate.class));
-    verify(mockDiaryRepository, times(1)).findReactionCountById(anyLong());
+    verify(mockDiaryReactionRepository, times(1)).countByDiaryId(anyLong());
   }
 
   @Test
@@ -256,6 +258,6 @@ public class DiaryServiceTest {
 
     assertThat(diaryException.getErrorSpec()).isEqualTo(DiaryErrorSpec.DIARY_NOT_FOUND);
     verify(mockDiaryRepository, times(1)).findByMemberIdAndDate(anyLong(), any(LocalDate.class));
-    verify(mockDiaryRepository, times(0)).findReactionCountById(anyLong());
+    verify(mockDiaryReactionRepository, times(0)).countByDiaryId(anyLong());
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -218,7 +218,7 @@ public class DiaryServiceTest {
 
     when(mockDiaryRepository.findByMemberIdAndDate(anyLong(), any(LocalDate.class)))
         .thenReturn(Optional.of(diary));
-    when(mockDiaryReactionRepository.countByDiaryId(anyLong()))
+    when(mockDiaryReactionRepository.countEachByDiaryId(anyLong()))
         .thenReturn(Optional.of(mockReactionCount));
 
     DiaryViewDetailResponse response = diaryService.getDetail(principal, requestDate);
@@ -241,7 +241,7 @@ public class DiaryServiceTest {
             });
 
     verify(mockDiaryRepository, times(1)).findByMemberIdAndDate(anyLong(), any(LocalDate.class));
-    verify(mockDiaryReactionRepository, times(1)).countByDiaryId(anyLong());
+    verify(mockDiaryReactionRepository, times(1)).countEachByDiaryId(anyLong());
   }
 
   @Test
@@ -258,6 +258,6 @@ public class DiaryServiceTest {
 
     assertThat(diaryException.getErrorSpec()).isEqualTo(DiaryErrorSpec.DIARY_NOT_FOUND);
     verify(mockDiaryRepository, times(1)).findByMemberIdAndDate(anyLong(), any(LocalDate.class));
-    verify(mockDiaryReactionRepository, times(0)).countByDiaryId(anyLong());
+    verify(mockDiaryReactionRepository, times(0)).countEachByDiaryId(anyLong());
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
@@ -12,9 +12,13 @@ import static org.mockito.Mockito.when;
 import com.heartsave.todaktodak_api.common.BaseTestEntity;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
+import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
+import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
 import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
 import com.heartsave.todaktodak_api.diary.exception.DiaryNotFoundException;
+import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.diary.repository.PublicDiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -27,12 +31,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 class PublicDiaryServiceTest {
   @Mock private DiaryRepository mockDiaryRepository;
   @Mock private PublicDiaryRepository mockPublicDiaryRepository;
+  @Mock private DiaryReactionRepository mockDiaryReactionRepository;
   @InjectMocks private PublicDiaryService publicDiaryService;
 
   private TodakUser principal;
@@ -92,5 +98,79 @@ class PublicDiaryServiceTest {
         .isEqualTo(DiaryErrorSpec.DIARY_NOT_FOUND);
 
     verify(mockPublicDiaryRepository, times(0)).save(any());
+  }
+
+  @Test
+  @DisplayName("toggleReactionStatus - 반응 추가/삭제 토글 테스트")
+  void toggleReactionStatus() {
+    PublicDiaryReactionRequest request =
+        new PublicDiaryReactionRequest(diary.getId(), DiaryReactionType.LIKE);
+    DiaryReactionEntity reactionEntity =
+        DiaryReactionEntity.builder()
+            .memberEntity(MemberEntity.createById(member.getId()))
+            .diaryEntity(DiaryEntity.createById(diary.getId()))
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+
+    when(mockDiaryReactionRepository.save(any(DiaryReactionEntity.class)))
+        .thenReturn(reactionEntity);
+
+    // 첫 번째 - 반응 추가
+    publicDiaryService.toggleReactionStatus(principal, request);
+
+    verify(mockDiaryReactionRepository, times(1)).save(any(DiaryReactionEntity.class));
+    verify(mockDiaryReactionRepository, times(0))
+        .deleteByMemberIdAndDiaryIdAndReactionType(
+            anyLong(), anyLong(), any(DiaryReactionType.class));
+
+    // 두 번째 - 준비
+    when(mockDiaryReactionRepository.save(any(DiaryReactionEntity.class)))
+        .thenThrow(new DataIntegrityViolationException("Duplicate entry"));
+    when(mockDiaryReactionRepository.deleteByMemberIdAndDiaryIdAndReactionType(
+            member.getId(), diary.getId(), DiaryReactionType.LIKE))
+        .thenReturn(1);
+
+    // 두 번재 - 반응 삭제
+    publicDiaryService.toggleReactionStatus(principal, request);
+
+    verify(mockDiaryReactionRepository, times(2)).save(any(DiaryReactionEntity.class));
+    verify(mockDiaryReactionRepository, times(1))
+        .deleteByMemberIdAndDiaryIdAndReactionType(
+            member.getId(), diary.getId(), DiaryReactionType.LIKE);
+  }
+
+  @Test
+  @DisplayName("toggleReactionStatus - 다른 타입의 반응 추가 테스트")
+  void toggleDifferentReactionTypes() {
+    PublicDiaryReactionRequest likeRequest =
+        new PublicDiaryReactionRequest(diary.getId(), DiaryReactionType.LIKE);
+    PublicDiaryReactionRequest cheeringRequest =
+        new PublicDiaryReactionRequest(diary.getId(), DiaryReactionType.CHEERING);
+
+    DiaryReactionEntity likeReaction =
+        DiaryReactionEntity.builder()
+            .memberEntity(MemberEntity.createById(member.getId()))
+            .diaryEntity(DiaryEntity.createById(diary.getId()))
+            .reactionType(DiaryReactionType.LIKE)
+            .build();
+
+    DiaryReactionEntity cheeringReaction =
+        DiaryReactionEntity.builder()
+            .memberEntity(MemberEntity.createById(member.getId()))
+            .diaryEntity(DiaryEntity.createById(diary.getId()))
+            .reactionType(DiaryReactionType.CHEERING)
+            .build();
+
+    when(mockDiaryReactionRepository.save(any(DiaryReactionEntity.class)))
+        .thenReturn(likeReaction)
+        .thenReturn(cheeringReaction);
+
+    publicDiaryService.toggleReactionStatus(principal, likeRequest);
+    publicDiaryService.toggleReactionStatus(principal, cheeringRequest);
+
+    verify(mockDiaryReactionRepository, times(2)).save(any(DiaryReactionEntity.class));
+    verify(mockDiaryReactionRepository, times(0))
+        .deleteByMemberIdAndDiaryIdAndReactionType(
+            anyLong(), anyLong(), any(DiaryReactionType.class));
   }
 }


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 공개 일기장에 반응 클릭시, 반응 추가, 이미 있는 반응이라면 삭제합니다.
- ```DiaryReactionEntity```의 ```memberId, diaryId, reactionType```에 unique 조건을 추가하여, 동일한 데이터 저장시 예외가 발생합니다.
- 예외가 발생하면 저장하려면 이벤트를 DB에서 삭제합니다.
- enum 객체에 ```@JsonValue```을 추가하여, json 요청을 주고 받을 때 enum의 소문자 영어 값이 들어가도록 하였습니다. (Camel 컨벤션)

## 리뷰 받고 싶은 내용
- 로직이 복잡하진 않습니다! 
- 반응 누르기와 관련해 동시성 문제 및 최적화를 고려해 보았을 때, 항상 반응(reaction)이 존재하는지 확인하는 쿼리를 날리고, 이에 대한 다음 쿼리를(save/delete) 진행하기 보다는(항상 2번의 쿼리),
```반응 삭제``` 보다 ```반응 추가``` 이벤트가 빈번하게 발생할 것으로 예상되어 ```save```를 먼저하고, 데이터가 있다면 ```delete```를 하는 로직을 작성하였습니다.
- 좀 더 완전한 동시성 문제 해결을 위해서는 DB의 ```Lock```에 대한 학습이 필요할 것 같습니다.

## 테스트 및 결과
- 로컬 테스트 확인했습니다.
- Repository의 역할 분리를 위해 ```DiaryRepository``` 에 있던 몇몇 테스트 메서드를 ```DiaryReactionRepositoey ```로 옮겨 변경감지가 되어 새로 추가된 것 처럼 보이는 것 들이 있습니다!ㅠ
- ```DiaryReactionRepository``` 에서 중복된 데이터를 저장하는 테스트 ```toggleReactionStatusDuplicateTest()``` 에서는 unique 조건 위반으로 ```ConstraintViolationException```가 발생하지만, 실제 ```PublicDiaryServcie```에서는 ```DataIntegrityViolationException```가 발생합니다. 
Hibernate 차원에서 발생하는  발생하는 ```Constraint...``` 에러를 Spring이 감싸서 ```DataIntegerity....```로 만들어 낸다고 합니다. (Wrapper 패턴 이용 , 상속 관계 X)
따라서 Test는 Spring 전체를 로딩하는게 아닌 Jpa만 로딩하기에(```@DataJpaTest``` 때문에)  hibernate 수준에서 예외가 발생하는 것이라 Test는 ```Const...``` , 비즈니스 로직은 ```DataInte...```로 예외를 처리했습니다.

## 참고자료
- Spring이 hibernate 예외를 감싼다. : https://docs.spring.io/spring-framework/reference/data-access/dao.html#dao-exceptions  
```
In addition to JDBC exceptions, Spring can also wrap JPA- and Hibernate-specific exceptions, converting them to a set of focused runtime exceptions.
```
- ConstraintViolationException : https://docs.jboss.org/hibernate/orm/3.5/javadocs/org/hibernate/exception/ConstraintViolationException.html
- DataIntegrityViolationException : https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/dao/DataIntegrityViolationException.html