### PR TITLE
Feature/todak 154/oauth2 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.netty:netty-resolver-dns-native-macos::osx-aarch_64'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorSpec implements ErrorSpec {
   INCORRECT_USERNAME_PASSWORD(
       HttpStatus.UNAUTHORIZED, "AUTH-001", "아이디 또는 비밀번호가 틀렸습니다.", "로그인이 실패됐습니다."),
-  DUPLICATED_INFORMATION(HttpStatus.CONFLICT, "AUTH-002", "중복된 정보가 있습니다.", "회원가입 요청 실패");
+  DUPLICATED_INFORMATION(HttpStatus.CONFLICT, "AUTH-002", "중복된 정보가 있습니다.", "회원가입 요청 실패"),
+  OAUTH_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-003", "소셜 로그인이 실패됐습니다.", "OAuth2 로그인 실패");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
@@ -10,7 +10,8 @@ public enum AuthErrorSpec implements ErrorSpec {
   INCORRECT_USERNAME_PASSWORD(
       HttpStatus.UNAUTHORIZED, "AUTH-001", "아이디 또는 비밀번호가 틀렸습니다.", "로그인이 실패됐습니다."),
   DUPLICATED_INFORMATION(HttpStatus.CONFLICT, "AUTH-002", "중복된 정보가 있습니다.", "회원가입 요청 실패"),
-  OAUTH_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-003", "소셜 로그인이 실패됐습니다.", "OAuth2 로그인 실패");
+  OAUTH_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-003", "소셜 로그인이 실패됐습니다.", "OAuth2 로그인 실패"),
+  OAUTH_DUPLICATED_EMAIL(HttpStatus.UNAUTHORIZED, "AUTH-004", "이미 가입된 계정입니다.", "OAuth2 중복 회원가입 시도");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/TodakUserDetailsService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/TodakUserDetailsService.java
@@ -3,6 +3,7 @@ package com.heartsave.todaktodak_api.common.security;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -20,6 +21,12 @@ public class TodakUserDetailsService implements UserDetailsService {
         memberRepository
             .findMemberEntityByLoginId(username)
             .orElseThrow(() -> new UsernameNotFoundException("USER NOT FOUND"));
-    return TodakUser.from(memberEntity);
+    return TodakUser.builder()
+        .id(memberEntity.getId())
+        .username(memberEntity.getLoginId())
+        .password(memberEntity.getPassword())
+        .role(memberEntity.getRole().name())
+        .attributes(Map.of())
+        .build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
@@ -59,7 +59,6 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
       Authentication authentication)
       throws IOException {
     TodakUser user = (TodakUser) authentication.getPrincipal();
-    user.removePassword();
     var accessToken = JwtUtils.issueToken(user, ACCESS_TYPE);
     var refreshToken = JwtUtils.issueToken(user, REFRESH_TYPE);
     var refreshCookie = CookieUtils.createValidCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken);

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
@@ -1,7 +1,7 @@
 package com.heartsave.todaktodak_api.common.security.component.jwt;
 
 import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.*;
-import static jakarta.servlet.http.HttpServletResponse.SC_NO_CONTENT;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -63,7 +63,7 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
     var refreshToken = JwtUtils.issueToken(user, REFRESH_TYPE);
     var refreshCookie = CookieUtils.createValidCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken);
     response.addCookie(refreshCookie);
-    response.setStatus(SC_NO_CONTENT);
+    response.setStatus(SC_OK);
     setResponseHeader(response);
 
     LoginResponse dto = getResponseBody(authentication, accessToken);

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
@@ -62,7 +62,6 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
     var accessToken = JwtUtils.issueToken(user, ACCESS_TYPE);
     var refreshToken = JwtUtils.issueToken(user, REFRESH_TYPE);
     var refreshCookie = CookieUtils.createValidCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken);
-
     response.addCookie(refreshCookie);
     response.setStatus(SC_NO_CONTENT);
     setResponseHeader(response);

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtAuthFilter.java
@@ -59,6 +59,7 @@ public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
       Authentication authentication)
       throws IOException {
     TodakUser user = (TodakUser) authentication.getPrincipal();
+    user.removePassword();
     var accessToken = JwtUtils.issueToken(user, ACCESS_TYPE);
     var refreshToken = JwtUtils.issueToken(user, REFRESH_TYPE);
     var refreshCookie = CookieUtils.createValidCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken);

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -5,6 +5,7 @@ import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
 import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
+import com.heartsave.todaktodak_api.common.security.TodakUserDetailsService;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -23,14 +24,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
 public class JwtValidationFilter extends OncePerRequestFilter {
-  private final UserDetailsService userDetailsService;
+  private final TodakUserDetailsService userDetailsService;
   private final ObjectMapper objectMapper;
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -90,11 +90,11 @@ public class JwtValidationFilter extends OncePerRequestFilter {
   }
 
   private Authentication getAuthentication(String token) {
-    return new UsernamePasswordAuthenticationToken(
-        JwtUtils.extractSubject(token), "", getUser(token).getAuthorities());
+    TodakUser user = getUser(token);
+    return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
   }
 
   private TodakUser getUser(String token) {
-    return (TodakUser) userDetailsService.loadUserByUsername(JwtUtils.extractSubject(token));
+    return (TodakUser) userDetailsService.loadUserByUsername(JwtUtils.extractUsername(token));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -1,11 +1,11 @@
 package com.heartsave.todaktodak_api.common.security.component.jwt;
 
 import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.*;
+import static com.heartsave.todaktodak_api.common.security.util.JwtUtils.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
 import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
-import com.heartsave.todaktodak_api.common.security.TodakUserDetailsService;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -30,7 +30,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 @RequiredArgsConstructor
 public class JwtValidationFilter extends OncePerRequestFilter {
-  private final TodakUserDetailsService userDetailsService;
   private final ObjectMapper objectMapper;
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -90,12 +89,15 @@ public class JwtValidationFilter extends OncePerRequestFilter {
   }
 
   private Authentication getAuthentication(String token) {
-    TodakUser user = getUser(token);
-    user.removePassword();
+    TodakUser user = extractUserFromToken(token);
     return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
   }
 
-  private TodakUser getUser(String token) {
-    return (TodakUser) userDetailsService.loadUserByUsername(JwtUtils.extractUsername(token));
+  private TodakUser extractUserFromToken(String token) {
+    return TodakUser.builder()
+        .id(extractSubject(token))
+        .username(extractUsername(token))
+        .role(extractRole(token))
+        .build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -43,7 +43,6 @@ public class JwtValidationFilter extends OncePerRequestFilter {
     if (token == null) {
       logger.error("NO TOKEN: {}", token);
       filterChain.doFilter(request, response);
-      //      setErrorResponse(response, TokenErrorSpec.INVALID_TOKEN);
       return;
     }
     try {

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -42,7 +42,8 @@ public class JwtValidationFilter extends OncePerRequestFilter {
 
     if (token == null) {
       logger.error("NO TOKEN: {}", token);
-      setErrorResponse(response, TokenErrorSpec.INVALID_TOKEN);
+      filterChain.doFilter(request, response);
+      //      setErrorResponse(response, TokenErrorSpec.INVALID_TOKEN);
       return;
     }
     try {

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -91,6 +91,7 @@ public class JwtValidationFilter extends OncePerRequestFilter {
 
   private Authentication getAuthentication(String token) {
     TodakUser user = getUser(token);
+    user.removePassword();
     return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -5,8 +5,6 @@ import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
 import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
-import com.heartsave.todaktodak_api.common.security.TodakUserDetailsService;
-import com.heartsave.todaktodak_api.common.security.constant.JwtConstant;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/OAuth2SuccessHandler.java
@@ -1,10 +1,17 @@
 package com.heartsave.todaktodak_api.common.security.component.oauth2;
 
-import jakarta.servlet.ServletException;
+import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.*;
+
+import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.common.security.util.CookieUtils;
+import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -12,8 +19,22 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  @Value("${base.url}")
+  private String BASE_URL;
+
+  @Value("${base.port}")
+  private String BASE_PORT;
+
   @Override
   public void onAuthenticationSuccess(
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-      throws IOException, ServletException {}
+      throws IOException {
+    logger.info("OAUTH2 SUCCESS: {}", authentication.getPrincipal());
+    String refreshToken =
+        JwtUtils.issueToken((TodakUser) authentication.getPrincipal(), REFRESH_TYPE);
+    response.addCookie(CookieUtils.createValidCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken));
+    response.sendRedirect(BASE_URL + ":" + BASE_PORT);
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/Oauth2FailureHandler.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/Oauth2FailureHandler.java
@@ -1,6 +1,9 @@
 package com.heartsave.todaktodak_api.common.security.component.oauth2;
 
+import static com.heartsave.todaktodak_api.common.security.constant.Oauth2ErrorConstant.DUPLICATED_EMAIL_ERROR;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -8,6 +11,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +26,26 @@ public class Oauth2FailureHandler implements AuthenticationFailureHandler {
       throws IOException {
     response.setStatus(HttpStatus.UNAUTHORIZED.value());
     response.setContentType("application/json;charset=UTF-8");
-    response.getWriter().write(objectMapper.writeValueAsString(AuthErrorSpec.OAUTH_LOGIN_FAIL));
+    if (!(exception instanceof OAuth2AuthenticationException e)) return;
+    setResponseBody(response, e);
+  }
+
+  private void setResponseBody(HttpServletResponse response, OAuth2AuthenticationException e)
+      throws IOException {
+    // 중복 이메일로 회원가입
+    if (DUPLICATED_EMAIL_ERROR.getErrorCode().equals(e.getError().getErrorCode())) {
+      response
+          .getWriter()
+          .write(
+              objectMapper.writeValueAsString(
+                  ErrorResponse.from(AuthErrorSpec.OAUTH_DUPLICATED_EMAIL)));
+    }
+    // 이외
+    else {
+      response
+          .getWriter()
+          .write(
+              objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.OAUTH_LOGIN_FAIL)));
+    }
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/Oauth2FailureHandler.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/Oauth2FailureHandler.java
@@ -1,10 +1,12 @@
 package com.heartsave.todaktodak_api.common.security.component.oauth2;
 
-import jakarta.servlet.ServletException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -12,8 +14,14 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class Oauth2FailureHandler implements AuthenticationFailureHandler {
+  private final ObjectMapper objectMapper;
+
   @Override
   public void onAuthenticationFailure(
       HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
-      throws IOException, ServletException {}
+      throws IOException {
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setContentType("application/json;charset=UTF-8");
+    response.getWriter().write(objectMapper.writeValueAsString(AuthErrorSpec.OAUTH_LOGIN_FAIL));
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2Attribute.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2Attribute.java
@@ -1,0 +1,54 @@
+package com.heartsave.todaktodak_api.common.security.component.oauth2;
+
+import static com.heartsave.todaktodak_api.common.security.constant.ConstraintConstant.Member.LOGIN_ID_MAX_SIZE;
+
+import java.util.Map;
+import lombok.Getter;
+
+// 소셜 로그인별로 정형화된 형식의 리소스로 가공
+@Getter
+public class TodakOauth2Attribute {
+  private static final String NAVER = "naver";
+  private static final String KAKAO = "kakao";
+  private static final String GOOGLE = "google";
+
+  private final String username;
+  private final String email;
+
+  private TodakOauth2Attribute(String username, String email) {
+    this.username = username;
+    this.email = email;
+  }
+
+  //
+  public static TodakOauth2Attribute of(Map<String, Object> attributes, String authType) {
+    return switch (authType) {
+      case NAVER -> ofNaver(attributes);
+      case KAKAO -> ofKakao(attributes);
+      case GOOGLE -> ofGoogle(attributes);
+      default -> null;
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static TodakOauth2Attribute ofKakao(Map<String, Object> attributes) {
+    String id = String.valueOf(attributes.get("id")); // Long -> String 변환
+    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+    String email = (String) kakaoAccount.get("email");
+    return new TodakOauth2Attribute(id + "_" + KAKAO, email);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static TodakOauth2Attribute ofNaver(Map<String, Object> attributes) {
+    Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+    String id = (String) response.get("id");
+    id = id.substring(0, Math.min(id.length(), LOGIN_ID_MAX_SIZE - 6));
+    String email = (String) response.get("email");
+    return new TodakOauth2Attribute(id + "_" + NAVER, email);
+  }
+
+  private static TodakOauth2Attribute ofGoogle(Map<String, Object> attributes) {
+    return new TodakOauth2Attribute(
+        attributes.get("sub") + "_" + GOOGLE, (String) attributes.get("email"));
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2Attribute.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2Attribute.java
@@ -2,11 +2,15 @@ package com.heartsave.todaktodak_api.common.security.component.oauth2;
 
 import static com.heartsave.todaktodak_api.common.security.constant.ConstraintConstant.Member.LOGIN_ID_MAX_SIZE;
 
+import com.heartsave.todaktodak_api.common.security.domain.AuthType;
 import java.util.Map;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 // 소셜 로그인별로 정형화된 형식의 리소스로 가공
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class TodakOauth2Attribute {
   private static final String NAVER = "naver";
   private static final String KAKAO = "kakao";
@@ -14,11 +18,7 @@ public class TodakOauth2Attribute {
 
   private final String username;
   private final String email;
-
-  private TodakOauth2Attribute(String username, String email) {
-    this.username = username;
-    this.email = email;
-  }
+  private final AuthType authType;
 
   //
   public static TodakOauth2Attribute of(Map<String, Object> attributes, String authType) {
@@ -35,7 +35,7 @@ public class TodakOauth2Attribute {
     String id = String.valueOf(attributes.get("id")); // Long -> String 변환
     Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
     String email = (String) kakaoAccount.get("email");
-    return new TodakOauth2Attribute(id + "_" + KAKAO, email);
+    return new TodakOauth2Attribute(id + "_" + KAKAO, email, AuthType.KAKAO);
   }
 
   @SuppressWarnings("unchecked")
@@ -44,11 +44,18 @@ public class TodakOauth2Attribute {
     String id = (String) response.get("id");
     id = id.substring(0, Math.min(id.length(), LOGIN_ID_MAX_SIZE - 6));
     String email = (String) response.get("email");
-    return new TodakOauth2Attribute(id + "_" + NAVER, email);
+    return new TodakOauth2Attribute(id + "_" + NAVER, email, AuthType.NAVER);
   }
 
   private static TodakOauth2Attribute ofGoogle(Map<String, Object> attributes) {
     return new TodakOauth2Attribute(
-        attributes.get("sub") + "_" + GOOGLE, (String) attributes.get("email"));
+        attributes.get("sub") + "_" + GOOGLE, (String) attributes.get("email"), AuthType.GOOGLE);
+  }
+
+  @Override
+  public String toString() {
+    return """
+USERNAME: %s, EMAIL: %s, AUTH TYPE: %s"""
+        .formatted(username, email, authType.name());
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2UserDetailsService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2UserDetailsService.java
@@ -5,6 +5,7 @@ import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.member.domain.TodakRole;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +37,12 @@ public class TodakOauth2UserDetailsService extends DefaultOAuth2UserService {
       throw new OAuth2AuthenticationException(Oauth2ErrorConstant.DUPLICATED_EMAIL_ERROR);
     }
     // 저장 성공시 인증 정보 생성
-    return TodakUser.from(member);
+    return TodakUser.builder()
+        .id(member.getId())
+        .username(member.getLoginId())
+        .role(member.getRole().name())
+        .attributes(Map.of())
+        .build();
   }
 
   private MemberEntity getOrSave(TodakOauth2Attribute attribute) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2UserDetailsService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2UserDetailsService.java
@@ -1,5 +1,9 @@
 package com.heartsave.todaktodak_api.common.security.component.oauth2;
 
+import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.member.domain.TodakRole;
+import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,14 +13,39 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+// 리소스 -> MemberEntity와 TodakUser로 변환
+//
 @Service
 @RequiredArgsConstructor
 public class TodakOauth2UserDetailsService extends DefaultOAuth2UserService {
+  private final MemberRepository memberRepository;
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
     OAuth2User user = super.loadUser(request);
-    return null;
+    TodakOauth2Attribute attribute =
+        TodakOauth2Attribute.of(
+            user.getAttributes(), request.getClientRegistration().getRegistrationId());
+    if (attribute == null) return null;
+    logger.info("OAUTH2 RESOURCE - {}", attribute);
+    // 회원 저장
+    MemberEntity member = memberRepository.save(createMember(attribute));
+    // 저장 성공시 인증 정보 생성
+    return TodakUser.from(member);
+  }
+
+  private MemberEntity createMember(TodakOauth2Attribute attribute) {
+    return MemberEntity.builder()
+        .authType(attribute.getAuthType())
+        .email(attribute.getEmail())
+        .role(TodakRole.ROLE_TEMP)
+        .nickname(createNickname(attribute.getEmail(), attribute.getAuthType().name()))
+        .loginId(attribute.getUsername())
+        .build();
+  }
+
+  private String createNickname(String email, String authType) {
+    return email.split("@")[0] + "_" + authType;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
@@ -70,8 +70,7 @@ public class SecurityConfig {
         .sessionManagement(
             sessionManagement ->
                 sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .addFilterBefore(
-            new JwtValidationFilter(userDetailsService, objectMapper), JwtAuthFilter.class)
+        .addFilterBefore(new JwtValidationFilter(objectMapper), JwtAuthFilter.class)
         .addFilterBefore(
             new JwtAuthFilter(authenticationManager, objectMapper),
             UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
@@ -1,11 +1,15 @@
 package com.heartsave.todaktodak_api.common.security.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.common.security.TodakUserDetailsService;
+import com.heartsave.todaktodak_api.common.security.component.AccessDeniedHandlerImpl;
+import com.heartsave.todaktodak_api.common.security.component.AuthenticationEntryPointImpl;
 import com.heartsave.todaktodak_api.common.security.component.jwt.JwtAuthFilter;
 import com.heartsave.todaktodak_api.common.security.component.jwt.JwtLogoutFilter;
 import com.heartsave.todaktodak_api.common.security.component.jwt.JwtValidationFilter;
 import com.heartsave.todaktodak_api.common.security.component.oauth2.OAuth2SuccessHandler;
 import com.heartsave.todaktodak_api.common.security.component.oauth2.Oauth2FailureHandler;
+import com.heartsave.todaktodak_api.common.security.component.oauth2.TodakOauth2UserDetailsService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,11 +20,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -31,12 +31,12 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
-  private final AuthenticationEntryPoint authenticationEntryPoint;
-  private final AccessDeniedHandler accessDeniedHandler;
+  private final AuthenticationEntryPointImpl authenticationEntryPoint;
+  private final AccessDeniedHandlerImpl accessDeniedHandler;
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
   private final Oauth2FailureHandler oauth2FailureHandler;
-  private final UserDetailsService userDetailsService;
-  private final DefaultOAuth2UserService oauth2UserDetailsService;
+  private final TodakUserDetailsService userDetailsService;
+  private final TodakOauth2UserDetailsService oauth2UserDetailsService;
   private final JwtLogoutFilter jwtLogoutFilter;
   private final ObjectMapper objectMapper;
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/constant/ConstraintConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/constant/ConstraintConstant.java
@@ -11,6 +11,6 @@ public final class ConstraintConstant {
     public static final int EMAIL_MAX_SIZE = 50;
     public static final int NICKNAME_MAX_SIZE = 50;
     public static final int LOGIN_ID_MAX_SIZE = 50;
-    public static final int PASSWORD_MAX_SIZE = 30;
+    public static final int PASSWORD_MAX_SIZE = 80;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/constant/Oauth2ErrorConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/constant/Oauth2ErrorConstant.java
@@ -1,0 +1,9 @@
+package com.heartsave.todaktodak_api.common.security.constant;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+public final class Oauth2ErrorConstant {
+  public static final String DUPLICATED_EMAIL_ERROR_KEY = "DUPLICATED_EMAIL";
+  public static final OAuth2Error DUPLICATED_EMAIL_ERROR =
+      new OAuth2Error(DUPLICATED_EMAIL_ERROR_KEY, "중복된 이메일로 회원가입 시도", null);
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
@@ -1,6 +1,5 @@
 package com.heartsave.todaktodak_api.common.security.domain;
 
-import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
@@ -13,20 +12,18 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Builder
 public class TodakUser implements UserDetails, OAuth2User, Serializable {
 
   private final Long id;
   private final String username;
   private final String role;
   private final Map<String, Object> attributes;
+  private String password;
 
-  public static TodakUser from(MemberEntity entity) {
-    return new TodakUser(entity.getId(), entity.getLoginId(), entity.getRole().name(), Map.of());
-  }
-
-  public static TodakUser of(
-      Long id, String username, String role, Map<String, Object> attributes) {
-    return new TodakUser(id, username, role, attributes);
+  // 인증 성공 후 컨트롤러 진입 전에 삭제
+  public void removePassword() {
+    password = "";
   }
 
   @Override
@@ -41,7 +38,7 @@ public class TodakUser implements UserDetails, OAuth2User, Serializable {
 
   @Override
   public String getPassword() {
-    return "";
+    return password;
   }
 
   @Override

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
@@ -10,9 +10,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@Builder
 public class TodakUser implements UserDetails, OAuth2User, Serializable {
 
   private final Long id;
@@ -20,6 +18,16 @@ public class TodakUser implements UserDetails, OAuth2User, Serializable {
   private final String role;
   private final Map<String, Object> attributes;
   private String password;
+
+  @Builder
+  private TodakUser(
+      Long id, String username, String role, Map<String, Object> attributes, String password) {
+    this.id = id;
+    this.username = username;
+    this.role = role;
+    this.attributes = attributes;
+    this.password = password;
+  }
 
   // 인증 성공 후 컨트롤러 진입 전에 삭제
   public void removePassword() {

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
@@ -29,11 +29,6 @@ public class TodakUser implements UserDetails, OAuth2User, Serializable {
     this.password = password;
   }
 
-  // 인증 성공 후 컨트롤러 진입 전에 삭제
-  public void removePassword() {
-    password = "";
-  }
-
   @Override
   public Map<String, Object> getAttributes() {
     return attributes;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
@@ -73,4 +73,11 @@ public class TodakUser implements UserDetails, OAuth2User, Serializable {
   public String getName() {
     return this.username;
   }
+
+  @Override
+  public String toString() {
+    return """
+ID: %s, USERNAME: %s, ROLE: %s"""
+        .formatted(id, username, role);
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/util/CookieUtils.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/util/CookieUtils.java
@@ -1,7 +1,6 @@
 package com.heartsave.todaktodak_api.common.security.util;
 
 import jakarta.annotation.Nullable;
-import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
@@ -12,11 +11,7 @@ import org.springframework.stereotype.Component;
 public class CookieUtils {
   private static Long MAX_AGE;
 
-  @Value("${jwt.refresh-expire-time}")
-  Long refreshTokenExpireTimeMilliSecond;
-
-  @PostConstruct
-  void init() {
+  private CookieUtils(@Value("${jwt.refresh-expire-time}") Long refreshTokenExpireTimeMilliSecond) {
     MAX_AGE = refreshTokenExpireTimeMilliSecond;
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/util/CookieUtils.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/util/CookieUtils.java
@@ -1,6 +1,7 @@
 package com.heartsave.todaktodak_api.common.security.util;
 
 import jakarta.annotation.Nullable;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
@@ -11,7 +12,13 @@ import org.springframework.stereotype.Component;
 public class CookieUtils {
   private static Long MAX_AGE;
 
-  private CookieUtils(@Value("${jwt.refresh-expire-time}") Long MAX_AGE) {}
+  @Value("${jwt.refresh-expire-time}")
+  Long refreshTokenExpireTimeMilliSecond;
+
+  @PostConstruct
+  void init() {
+    MAX_AGE = refreshTokenExpireTimeMilliSecond;
+  }
 
   public static Cookie createValidCookie(String key, String value) {
     Cookie cookie = new Cookie(key, value);

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
@@ -56,7 +56,7 @@ public class JwtUtils {
         .compact();
   }
 
-  private static String extractRole(String token) {
+  public static String extractRole(String token) {
     return extractAllClaims(token).get(ROLE, String.class);
   }
 
@@ -68,8 +68,8 @@ public class JwtUtils {
     return extractAllClaims(token).get(TYPE, String.class);
   }
 
-  public static String extractSubject(String token) {
-    return extractAllClaims(token).getSubject();
+  public static Long extractSubject(String token) {
+    return Long.valueOf(extractAllClaims(token).getSubject());
   }
 
   public static Claims extractAllClaims(String token) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,17 +18,25 @@ public class JwtUtils {
   private static final String ROLE = "role";
   private static final String TYPE = "type";
   private static final String USERNAME = "username";
-  private static String JWT_SECRET_KEY;
   private static Long ACCESS_TOKEN_EXPIRE_TIME_MILLI_SECOND;
   private static Long REFRESH_TOKEN_EXPIRE_TIME_MILLI_SECOND;
   private static SecretKey key;
 
-  private JwtUtils(
-      @Value("${jwt.secret-key}") String JWT_SECRET_KEY,
-      @Value("${jwt.access-expire-time}") Long ACCESS_TOKEN_EXPIRE_TIME_MILLI_SECOND,
-      @Value("${jwt.refresh-expire-time}") Long REFRESH_TOKEN_EXPIRE_TIME_MILLI_SECOND) {
-    var keyBytes = Decoders.BASE64.decode(JWT_SECRET_KEY);
+  @Value("${jwt.secret-key}")
+  String jwtSecretKey;
+
+  @Value("${jwt.access-expire-time}")
+  Long accessTokenExpireTimeMilliSecond;
+
+  @Value("${jwt.refresh-expire-time}")
+  Long refreshTokenExpireTimeMilliSecond;
+
+  @PostConstruct
+  void setup() {
+    var keyBytes = Decoders.BASE64.decode(jwtSecretKey);
     key = Keys.hmacShaKeyFor(keyBytes);
+    ACCESS_TOKEN_EXPIRE_TIME_MILLI_SECOND = accessTokenExpireTimeMilliSecond;
+    REFRESH_TOKEN_EXPIRE_TIME_MILLI_SECOND = refreshTokenExpireTimeMilliSecond;
   }
 
   public static String issueToken(TodakUser user, String type) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
@@ -6,7 +6,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,17 +21,10 @@ public class JwtUtils {
   private static Long REFRESH_TOKEN_EXPIRE_TIME_MILLI_SECOND;
   private static SecretKey key;
 
-  @Value("${jwt.secret-key}")
-  String jwtSecretKey;
-
-  @Value("${jwt.access-expire-time}")
-  Long accessTokenExpireTimeMilliSecond;
-
-  @Value("${jwt.refresh-expire-time}")
-  Long refreshTokenExpireTimeMilliSecond;
-
-  @PostConstruct
-  void setup() {
+  private JwtUtils(
+      @Value("${jwt.secret-key}") String jwtSecretKey,
+      @Value("${jwt.access-expire-time}") Long accessTokenExpireTimeMilliSecond,
+      @Value("${jwt.refresh-expire-time}") Long refreshTokenExpireTimeMilliSecond) {
     var keyBytes = Decoders.BASE64.decode(jwtSecretKey);
     key = Keys.hmacShaKeyFor(keyBytes);
     ACCESS_TOKEN_EXPIRE_TIME_MILLI_SECOND = accessTokenExpireTimeMilliSecond;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/util/JwtUtils.java
@@ -60,6 +60,10 @@ public class JwtUtils {
     return extractAllClaims(token).get(ROLE, String.class);
   }
 
+  public static String extractUsername(String token) {
+    return extractAllClaims(token).get(USERNAME, String.class);
+  }
+
   public static String extractType(String token) {
     return extractAllClaims(token).get(TYPE, String.class);
   }

--- a/src/main/java/com/heartsave/todaktodak_api/config/JpaAuditConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/config/JpaAuditConfig.java
@@ -21,6 +21,7 @@ public class JpaAuditConfig {
             .map(SecurityContext::getAuthentication)
             .filter(Authentication::isAuthenticated)
             .map(Authentication::getPrincipal)
+            .filter(principal -> principal instanceof TodakUser)
             .map(TodakUser.class::cast)
             .map(TodakUser::getId);
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,9 @@ jwt:
   secret-key: ${JWT_SECRET_KEY:abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl}
   access-expire-time: ${ACCESS_EXPIRE_TIME:123456}
   refresh-expire-time: ${REFRESH_EXPIRE_TIME:12345678}
+base:
+  url: ${BASE_URL:http://localhost}
+  port: ${BASE_PORT:3000}
 ---
 spring:
   datasource:
@@ -23,23 +26,26 @@ spring:
             client-name: google
             client-id: ${GOOGLE_OAUTH_CLIENT_ID}
             client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
-            redirect-uri: ${${GOOGLE_OAUTH_REDIRECT_URI}}
+            redirect-uri: ${GOOGLE_OAUTH_REDIRECT_URI}
             authorization-grant-type: authorization_code
-            scope: email
+            scope:
+              - email
           naver:
             client-name: naver
             client-id: ${NAVER_OAUTH_CLIENT_ID}
             client-secret: ${NAVER_OAUTH_CLIENT_SECRET}
             redirect-uri: ${NAVER_OAUTH_REDIRECT_URI}
             authorization-grant-type: authorization_code
-            scope: email
+            scope:
+              - email
           kakao:
             client-name: kakao
             client-id: ${KAKAO_OAUTH_CLIENT_ID}
             client-secret: ${KAKAO_OAUTH_CLIENT_SECRET}
             redirect-uri: ${KAKAO_OAUTH_REDIRECT_URI}
             authorization-grant-type: authorization_code
-            scope: account_email
+            scope:
+              - account_email
             client-authentication-method: client_secret_post
         provider:
           naver:

--- a/src/test/java/com/heartsave/todaktodak_api/common/security/WithMockTodakUserSecurityContextFactory.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/security/WithMockTodakUserSecurityContextFactory.java
@@ -18,8 +18,8 @@ public class WithMockTodakUserSecurityContextFactory
     String username = annotation.username();
     long id = annotation.id();
     String role = annotation.role();
-
-    TodakUser user = TodakUser.of(id, username, role, Map.of());
+    TodakUser user =
+        TodakUser.builder().id(id).username(username).role(role).attributes(Map.of()).build();
 
     UsernamePasswordAuthenticationToken token =
         new UsernamePasswordAuthenticationToken(


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

## OAuth2 회원가입 구현
1. 중복 이메일에 대한 회원가입 차단
2. 회원가입 성공시 DB 저장후 리프레시 토큰 발급

OAuth2 흐름 과정에서 여러 객체들이 사용되는데 흐름은 다음과 같습니다.
![image](https://github.com/user-attachments/assets/b8825f9b-c685-4a0a-9995-ff9d59b193ea)

## 인증 정보(`TodakUser`) 구조 변경
모든 인증은 `TodakUser`로 진행되고, 기본 로그인의 경우 비밀번호를 검증해야합니다.

BEFORE: `TodakUser`가 비밀번호를 가지고 있지 않아, `getPassword`가 빈 문자열로 반환 -> `getPassword`를 통해 `PasswordEncoder`가 비밀번호 검증을 하기 때문에 오류 발생

AFTER: 비밀번호도 저장하게 하여 인증 처리, 인증 성공시 비밀번호 초기화

## 코드 리뷰 받고 싶은 부분
### Util 클래스 중복 환경 변수
`JwtUtils`와 `CookieUtils`에 외부에서 사용할 static이면서 환경변수인 필드가 있습니다.
static은 컴파일 타임에 초기화가 되어서 `@Value`가 적용되지 않아, null이 되는 문제가 있어서

이를 초기화해주기 위한 중복 필드를 만들어 처리했는데,
음,, 좀 더 좋은 방법이 있을까요?

## 테스트 및 결과
로컬 테스트 완료

## 관련 스크린샷 및 참고자료 (Optional)
close #43 