### PR TITLE
Feature/todak 173/email auth config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/heartsave/todaktodak_api/auth/controller/EmailController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/controller/EmailController.java
@@ -1,0 +1,36 @@
+package com.heartsave.todaktodak_api.auth.controller;
+
+import com.heartsave.todaktodak_api.auth.dto.request.EmailCheckRequest;
+import com.heartsave.todaktodak_api.auth.dto.request.EmailOtpCheckRequest;
+import com.heartsave.todaktodak_api.auth.exception.AuthException;
+import com.heartsave.todaktodak_api.auth.service.EmailService;
+import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "인증", description = "인증 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/email")
+public class EmailController {
+  private final EmailService emailService;
+
+  @PostMapping
+  public ResponseEntity<Void> verifyEmail(@Valid @RequestBody EmailCheckRequest dto) {
+    emailService.sendOtp(dto);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/otp")
+  public ResponseEntity<Void> verifyEmailOtp(@Valid @RequestBody EmailOtpCheckRequest dto) {
+    boolean isVerified = emailService.verifyOtp(dto);
+    if (isVerified) return ResponseEntity.noContent().build();
+    else throw new AuthException(AuthErrorSpec.INCORRECT_EMAIL_OTP);
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/auth/dto/request/EmailOtpCheckRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/dto/request/EmailOtpCheckRequest.java
@@ -7,11 +7,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-@Schema(description = "중복 확인 및 OTP 요청 데이터")
-public record EmailCheckRequest(
+@Schema(description = "OTP 검증 데이터")
+public record EmailOtpCheckRequest(
     @NotBlank(message = "Blank data")
         @Pattern(
             regexp = "^[^@.]+@[^@.]+\\.[^@.]+$",
             message = "올바른 이메일 형식이 아닙니다") // @와 . 사이에 문자 최소 1개 존재
         @Size(max = EMAIL_MAX_SIZE, message = "Exceed size")
-        String email) {}
+        String email,
+    @NotBlank(message = "Blank data") String emailOtp) {}

--- a/src/main/java/com/heartsave/todaktodak_api/auth/exception/AuthException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/exception/AuthException.java
@@ -6,6 +6,10 @@ import com.heartsave.todaktodak_api.common.exception.ErrorFieldBuilder;
 import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
 
 public final class AuthException extends BaseException {
+  public AuthException(ErrorSpec errorSpec) {
+    super(errorSpec, null);
+  }
+
   public AuthException(ErrorSpec errorSpec, SignUpRequest dto) {
     super(
         errorSpec,

--- a/src/main/java/com/heartsave/todaktodak_api/auth/exception/AuthException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/exception/AuthException.java
@@ -7,7 +7,7 @@ import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
 
 public final class AuthException extends BaseException {
   public AuthException(ErrorSpec errorSpec) {
-    super(errorSpec, null);
+    super(errorSpec, ErrorFieldBuilder.builder().build());
   }
 
   public AuthException(ErrorSpec errorSpec, SignUpRequest dto) {

--- a/src/main/java/com/heartsave/todaktodak_api/auth/service/EmailService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/service/EmailService.java
@@ -1,0 +1,69 @@
+package com.heartsave.todaktodak_api.auth.service;
+
+import com.heartsave.todaktodak_api.auth.dto.request.EmailCheckRequest;
+import com.heartsave.todaktodak_api.auth.dto.request.EmailOtpCheckRequest;
+import jakarta.mail.MessagingException;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+  private final JavaMailSender mailSender;
+
+  public void sendOtp(EmailCheckRequest dto) throws MessagingException {
+    var otp = createOtp();
+    var message = mailSender.createMimeMessage();
+    var helper = new MimeMessageHelper(message, true, "UTF-8");
+    setMessageContent(helper, otp);
+    mailSender.send(message);
+
+    // TODO: OTP 캐싱
+  }
+
+  public boolean verifyOtp(EmailOtpCheckRequest dto) {
+    return true;
+  }
+
+  private String createOtp() {
+    return RandomStringUtils.randomAlphanumeric(8);
+  }
+
+  private void setMessageContent(MimeMessageHelper helper, String otp) throws MessagingException {
+    helper.setSubject("토닥토닥 이메일 인증번호");
+    helper.setSentDate(new Date());
+    helper.setText(
+        String.format(
+            """
+        <!DOCTYPE html>
+        <html>
+        <body style="margin: 0; padding: 0; font-family: Arial, sans-serif;">
+            <div style="max-width: 600px; margin: 0 auto; padding: 20px; background-color: #FAF7F0;">
+                <div style="text-align: center; padding: 20px; background-color: #ffffff; border-radius: 8px; margin-bottom: 20px;">
+                    <h1 style="color: #4A4947; margin: 0;">인증번호 안내</h1>
+                </div>
+                <div style="background-color: #D8D2C2; padding: 30px; border-radius: 8px; text-align: center;">
+                    <p style="margin: 0 0 20px 0;">요청하신 인증번호를 안내드립니다.</p>
+
+                    <div style="background-color: #FAF7F0; padding: 20px; border-radius: 6px; margin: 20px 0;">
+                        <span style="font-size: 32px; letter-spacing: 5px; font-weight: bold; color: #000000;">%s</span>
+                    </div>
+
+                    <p style="margin: 0 0 10px 0;">인증번호는 <strong>3분</strong> 동안 유효합니다.</p>
+                    <p style="margin: 0 0 10px 0;">본인이 요청하지 않은 경우 이 메일을 무시하셔도 됩니다.</p>
+                </div>
+
+                <div style="text-align: center; color: #4A4947; font-size: 12px; margin-top: 20px;">
+                    <p style="margin: 0 0 5px 0;">본 메일은 발신전용이며 회신되지 않습니다.</p>
+                </div>
+            </div>
+        </body>
+        </html>
+            """,
+            otp));
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/auth/service/EmailService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/service/EmailService.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.Date;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -20,6 +21,9 @@ public class EmailService {
   private final JavaMailSender mailSender;
   private final RedisTemplate<String, String> redisTemplate;
   private final MemberRepository memberRepository;
+
+  @Value("${spring.mail.username}")
+  private String provider;
 
   private EmailService(
       JavaMailSender mailSender,
@@ -39,7 +43,7 @@ public class EmailService {
     var message = mailSender.createMimeMessage();
     try {
       var helper = new MimeMessageHelper(message, true, "UTF-8");
-      setMessageContent(helper, otp);
+      setMessageContent(helper, email, otp);
     } catch (MessagingException e) {
       throw new AuthException(AuthErrorSpec.EMAIL_OTP_SEND_FAIL);
     }
@@ -63,7 +67,10 @@ public class EmailService {
     return RandomStringUtils.randomAlphanumeric(8);
   }
 
-  private void setMessageContent(MimeMessageHelper helper, String otp) throws MessagingException {
+  private void setMessageContent(MimeMessageHelper helper, String email, String otp)
+      throws MessagingException {
+    helper.setFrom(provider);
+    helper.setTo(email);
     helper.setSubject("토닥토닥 이메일 인증번호");
     helper.setSentDate(new Date());
     helper.setText(
@@ -94,6 +101,7 @@ public class EmailService {
         </body>
         </html>
             """,
-            otp));
+            otp),
+        true);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
@@ -11,7 +11,10 @@ public enum AuthErrorSpec implements ErrorSpec {
       HttpStatus.UNAUTHORIZED, "AUTH-001", "아이디 또는 비밀번호가 틀렸습니다.", "로그인이 실패됐습니다."),
   DUPLICATED_INFORMATION(HttpStatus.CONFLICT, "AUTH-002", "중복된 정보가 있습니다.", "회원가입 요청 실패"),
   OAUTH_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-003", "소셜 로그인이 실패됐습니다.", "OAuth2 로그인 실패"),
-  OAUTH_DUPLICATED_EMAIL(HttpStatus.UNAUTHORIZED, "AUTH-004", "이미 가입된 계정입니다.", "OAuth2 중복 회원가입 시도");
+  OAUTH_DUPLICATED_EMAIL(HttpStatus.UNAUTHORIZED, "AUTH-004", "이미 가입된 계정입니다.", "OAuth2 중복 회원가입 시도"),
+  BASE_DUPLICATED_EMAIL(HttpStatus.CONFLICT, "AUTH-005", "이미 가입된 계정입니다.", "기본 중복 회원가입 시도"),
+  EMAIL_OTP_SEND_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "AUTH-006", "인증번호 전송이 실패됐습니다.", "OPT 전송 실패"),
+  INCORRECT_EMAIL_OTP(HttpStatus.CONFLICT, "AUTH-007", "잘못된 인증번호입니다.", "OPT 검증 실패");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/RedisConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.heartsave.todaktodak_api.common.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfig {
+  @Value("${spring.data.redis.host}")
+  private String REDIS_HOST;
+
+  @Value("${spring.data.redis.port}")
+  private Integer REDIS_PORT;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(REDIS_HOST, REDIS_PORT);
+  }
+
+  @Bean
+  public RedisTemplate<String, String> otpRedisTemplate(
+      RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory);
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/member/repository/MemberRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
   Optional<MemberEntity> findMemberEntityByNickname(String nickname);
 
   Optional<MemberEntity> findMemberEntityByEmail(String email);
+
+  boolean existsByEmail(String email);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,10 @@ spring:
           timeout: 5000
           starttls:
             enable: true
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 jwt:
   secret-key: ${JWT_SECRET_KEY:abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl}
   access-expire-time: ${ACCESS_EXPIRE_TIME:123456}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,18 @@ server:
 spring:
   profiles:
     active: "local"
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
 jwt:
   secret-key: ${JWT_SECRET_KEY:abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl}
   access-expire-time: ${ACCESS_EXPIRE_TIME:123456}


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

## 이메일 인증 및 OTP 검증
1. 의존성 및 이메일 전송 설정
2. 랜덤 알파벳+숫자 otp 발송
3. OTP 검증

## OTP 캐싱을 위한 Redis 연동

### OTP를 부여받은 클라이언트가 검증을 요청할때, 서버가 해당 이메일에 대한 OTP를 기억하고 있어야합니다.
이를 위해, Redis 캐시가 필요하다 판단했습니다.

**key(`String`)-value(`String`) `RedisTemplate`을 만들었고**

**`OTP:<이메일>` 형식의 key에 otp를 저장하게 하였습니다.
ttl은 3분으로 설정했습니다.**

## 리뷰 받고 싶은 내용

코드 스멜나는 부분이 있다면 클린하게 만들겠습니다.

## 테스트 및 결과
- 로컬 테스트 정상 완료
- OTP 이메일 예시
![Screenshot 2024-10-30 at 3 21 31 PM](https://github.com/user-attachments/assets/a58fa400-d22f-4b44-a05a-b582e6f84e0f)

## 관련 스크린샷 및 참고자료 (Optional)
[스프링부트 이메일 설정](https://velog.io/@dl-00-e8/%EA%B3%B5%EC%9E%91%EC%86%8C-Spring-Boot%EC%97%90%EC%84%9C-%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%A0%84%EC%86%A1%ED%95%98%EA%B8%B0)

#55 