### PR TITLE
Feature/todak 175/token reissue

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/auth/controller/AuthController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/controller/AuthController.java
@@ -3,11 +3,14 @@ package com.heartsave.todaktodak_api.auth.controller;
 import com.heartsave.todaktodak_api.auth.dto.request.LoginIdCheckRequest;
 import com.heartsave.todaktodak_api.auth.dto.request.NicknameCheckRequest;
 import com.heartsave.todaktodak_api.auth.dto.request.SignUpRequest;
+import com.heartsave.todaktodak_api.auth.dto.response.TokenReissueResponse;
 import com.heartsave.todaktodak_api.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -62,5 +65,17 @@ public class AuthController {
   public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest dto) {
     authService.signUp(dto);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @Operation(summary = "토큰 재발급")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+        @ApiResponse(responseCode = "401", description = "토큰 재발급 실패")
+      })
+  @PostMapping("/refresh-token")
+  public ResponseEntity<TokenReissueResponse> reissueToken(
+      HttpServletRequest request, HttpServletResponse response) {
+    return ResponseEntity.ok(authService.reissueToken(request, response));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/dto/response/LoginResponse.java
@@ -1,6 +1,10 @@
 package com.heartsave.todaktodak_api.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record LoginResponse(String username, String accessToken) {}
+@Schema(description = "로그인 API 응답 객체")
+public record LoginResponse(
+    @Schema(description = "로그인 아이디") String username,
+    @Schema(description = "인증 토큰") String accessToken) {}

--- a/src/main/java/com/heartsave/todaktodak_api/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/dto/response/TokenReissueResponse.java
@@ -1,0 +1,6 @@
+package com.heartsave.todaktodak_api.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenReissueResponse(String accessToken) {}

--- a/src/main/java/com/heartsave/todaktodak_api/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/dto/response/TokenReissueResponse.java
@@ -1,6 +1,8 @@
 package com.heartsave.todaktodak_api.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record TokenReissueResponse(String accessToken) {}
+@Schema(description = "토큰 재발급 API 응답 객체")
+public record TokenReissueResponse(@Schema(description = "재발급된 인증 토큰") String accessToken) {}

--- a/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
@@ -14,12 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class AuthService {
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
 
-  @Transactional
   public void signUp(SignUpRequest dto) {
     if (isDuplicated(dto)) throw new AuthException(AuthErrorSpec.DUPLICATED_INFORMATION, dto);
 

--- a/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
@@ -86,14 +86,14 @@ public class AuthService {
     try {
       JwtUtils.extractAllClaims(token);
       if (!isRefreshTokenType(token)) {
-        throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
+        throw new AuthException(AuthErrorSpec.ABNORMAL_ACCESS);
       }
     } catch (ExpiredJwtException e) {
       logger.error("토큰이 만료됐습니다. {}", token);
       throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
     } catch (Exception e) {
       logger.error("유효하지 않은 토큰입니다. {}", token);
-      throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
+      throw new AuthException(AuthErrorSpec.ABNORMAL_ACCESS);
     }
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
@@ -77,7 +77,7 @@ public class AuthService {
     }
     String token = refreshTokenCookie.getValue();
     if (token == null) {
-      throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
+      throw new AuthException(AuthErrorSpec.ABNORMAL_ACCESS);
     }
     return token;
   }

--- a/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
@@ -1,13 +1,28 @@
 package com.heartsave.todaktodak_api.auth.service;
 
+import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.*;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.heartsave.todaktodak_api.auth.dto.request.SignUpRequest;
+import com.heartsave.todaktodak_api.auth.dto.response.TokenReissueResponse;
 import com.heartsave.todaktodak_api.auth.exception.AuthException;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
+import com.heartsave.todaktodak_api.common.security.constant.JwtConstant;
 import com.heartsave.todaktodak_api.common.security.domain.AuthType;
+import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.common.security.util.CookieUtils;
+import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import com.heartsave.todaktodak_api.member.domain.TodakRole;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +33,47 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  public TokenReissueResponse reissueToken(
+      HttpServletRequest request, HttpServletResponse response) {
+    var retrievedRefreshTokenCookie =
+        CookieUtils.extractCookie(request, JwtConstant.REFRESH_TOKEN_COOKIE_KEY);
+    if (retrievedRefreshTokenCookie == null) throw new AuthException(AuthErrorSpec.ABNORMAL_ACCESS);
+
+    var token = retrievedRefreshTokenCookie.getValue();
+    logger.info("리프레시 토큰: {}", token);
+    if (token == null) throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
+    try {
+      JwtUtils.extractAllClaims(token);
+      if (!isRefreshTokenType(token)) throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
+    } catch (ExpiredJwtException e) {
+      logger.error("토큰이 만료됐습니다. {}", token);
+      throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
+    } catch (Exception e) {
+      logger.error("유효하지 않은 토큰입니다. {}", token);
+      throw new AuthException(AuthErrorSpec.RE_LOGIN_REQUIRED);
+    }
+
+    Long id = JwtUtils.extractSubject(token);
+    MemberEntity member =
+        memberRepository.findById(id).orElseThrow(() -> new AuthException(AuthErrorSpec.AUTH_FAIL));
+    var user =
+        TodakUser.builder()
+            .id(member.getId())
+            .username(member.getLoginId())
+            .role(member.getRole().name())
+            .build();
+    var accessToken = JwtUtils.issueToken(user, ACCESS_TYPE);
+    var refreshToken = JwtUtils.issueToken(user, REFRESH_TYPE);
+    var refreshCookie = CookieUtils.createValidCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken);
+    response.setContentType(APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(UTF_8.name());
+    response.addCookie(refreshCookie);
+    response.setStatus(SC_OK);
+
+    return TokenReissueResponse.builder().accessToken(accessToken).build();
+  }
 
   public void signUp(SignUpRequest dto) {
     if (isDuplicated(dto)) throw new AuthException(AuthErrorSpec.DUPLICATED_INFORMATION, dto);
@@ -33,6 +89,10 @@ public class AuthService {
             .build();
 
     memberRepository.save(newMember);
+  }
+
+  private boolean isRefreshTokenType(String token) {
+    return JwtUtils.extractType(token).equals(JwtConstant.REFRESH_TYPE);
   }
 
   private boolean isDuplicated(SignUpRequest dto) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
@@ -15,7 +15,8 @@ public enum AuthErrorSpec implements ErrorSpec {
   BASE_DUPLICATED_EMAIL(HttpStatus.CONFLICT, "AUTH-005", "이미 가입된 계정입니다.", "기본 중복 회원가입 시도"),
   EMAIL_OTP_SEND_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "AUTH-006", "인증번호 전송이 실패됐습니다.", "OPT 전송 실패"),
   INCORRECT_EMAIL_OTP(HttpStatus.CONFLICT, "AUTH-007", "잘못된 인증번호입니다.", "OPT 검증 실패"),
-  AUTH_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-008", "인증이 실패했습니다", "비정상 인증 에러");
+  ABNORMAL_ACCESS(HttpStatus.UNAUTHORIZED, "AUTH-008", "로그인이 필요합니다.", "비정상 접근 시도"),
+  AUTH_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-009", "인증이 실패했습니다", "비정상 인증 에러");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
@@ -14,7 +14,8 @@ public enum AuthErrorSpec implements ErrorSpec {
   OAUTH_DUPLICATED_EMAIL(HttpStatus.UNAUTHORIZED, "AUTH-004", "이미 가입된 계정입니다.", "OAuth2 중복 회원가입 시도"),
   BASE_DUPLICATED_EMAIL(HttpStatus.CONFLICT, "AUTH-005", "이미 가입된 계정입니다.", "기본 중복 회원가입 시도"),
   EMAIL_OTP_SEND_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "AUTH-006", "인증번호 전송이 실패됐습니다.", "OPT 전송 실패"),
-  INCORRECT_EMAIL_OTP(HttpStatus.CONFLICT, "AUTH-007", "잘못된 인증번호입니다.", "OPT 검증 실패");
+  INCORRECT_EMAIL_OTP(HttpStatus.CONFLICT, "AUTH-007", "잘못된 인증번호입니다.", "OPT 검증 실패"),
+  AUTH_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-008", "인증이 실패했습니다", "비정상 인증 에러");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
@@ -16,7 +16,9 @@ public enum AuthErrorSpec implements ErrorSpec {
   EMAIL_OTP_SEND_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "AUTH-006", "인증번호 전송이 실패됐습니다.", "OPT 전송 실패"),
   INCORRECT_EMAIL_OTP(HttpStatus.CONFLICT, "AUTH-007", "잘못된 인증번호입니다.", "OPT 검증 실패"),
   ABNORMAL_ACCESS(HttpStatus.UNAUTHORIZED, "AUTH-008", "로그인이 필요합니다.", "비정상 접근 시도"),
-  AUTH_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-009", "인증이 실패했습니다", "비정상 인증 에러");
+  AUTH_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-009", "인증이 실패했습니다", "비정상 인증 에러"),
+  RE_LOGIN_REQUIRED(
+      HttpStatus.UNAUTHORIZED, "AUTH-010", "다시 로그인을 해야합니다.", "리프레시 토큰 유효성 검사가 실패됐습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/TokenErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/TokenErrorSpec.java
@@ -7,9 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum TokenErrorSpec implements ErrorSpec {
-  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-001", "로그인 정보가 만료되었습니다.", "회원의 토큰이 만료되었습니다."),
-  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-002", "유효하지 않은 로그인 정보 입니다.", "회원의 토큰이 유효하지 않습니다."),
-  NON_EXISTENT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-003", "로그인이 필요합니다.", "액세스 토큰이 없는 요청입니다.");
+  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-001", "로그인 정보가 만료되었습니다.", "액세스 토큰이 만료되었습니다."),
+  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-002", "비정상 로그인 시도입니다.", "유효하지 않은 토큰으로 인증 시도"),
+  NON_EXISTENT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-003", "로그인 정보가 만료되었습니다.", "액세스 토큰이 없는 요청입니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/TokenErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/TokenErrorSpec.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum TokenErrorSpec implements ErrorSpec {
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-001", "로그인 정보가 만료되었습니다.", "회원의 토큰이 만료되었습니다."),
-  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-002", "유효하지 않은 로그인 정보 입니다.", "회원의 토큰이 유효하지 않습니다.");
+  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-002", "유효하지 않은 로그인 정보 입니다.", "회원의 토큰이 유효하지 않습니다."),
+  NON_EXISTENT_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN-003", "로그인이 필요합니다.", "액세스 토큰이 없는 요청입니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
@@ -1,13 +1,18 @@
 package com.heartsave.todaktodak_api.common.security.component;
 
+import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.NO_TOKEN_REQUEST_ATTRIBUTE_KEY;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
+import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
 import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -18,6 +23,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
   private final ObjectMapper objectMapper;
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   @Override
   public void commence(
@@ -25,22 +31,39 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
       HttpServletResponse response,
       AuthenticationException authException)
       throws IOException {
-    setResponseWithMessage(response, authException);
+    setResponseWithMessage(request, response, authException);
   }
 
-  private void setResponseWithMessage(HttpServletResponse response, AuthenticationException e)
+  private void setResponseWithMessage(
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException e)
       throws IOException {
+    response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpStatus.UNAUTHORIZED.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-    // 토큰 관련 에러 발생 기대
+    // 토큰이 없는 요청에 대한 응답
+    if (isNoTokenRequest(request)) {
+      response
+          .getWriter()
+          .write(
+              objectMapper.writeValueAsString(
+                  ErrorResponse.from(
+                      (ErrorSpec) request.getAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY))));
+      return;
+    }
+
+    // 토큰 유효성 검사 실패에 대한 응답
     try {
       TokenErrorSpec spec = TokenErrorSpec.valueOf(e.getMessage());
       response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.from(spec)));
-    } catch (IllegalArgumentException ex) {
+    } catch (Exception ex) {
       response
           .getWriter()
           .write(objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.AUTH_FAIL)));
     }
+  }
+
+  private boolean isNoTokenRequest(HttpServletRequest request) {
+    return request.getAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY) != null;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
 import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
-import com.heartsave.todaktodak_api.common.security.constant.JwtConstant;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -34,15 +33,14 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
     response.setStatus(HttpStatus.UNAUTHORIZED.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-    // 비정상 인증 토큰
-    if (e.getMessage().equals(JwtConstant.INVALID_TOKEN_ERROR_DETAIL)) {
+    // 토큰 관련 에러 발생 기대
+    try {
+      TokenErrorSpec spec = TokenErrorSpec.valueOf(e.getMessage());
+      response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.from(spec)));
+    } catch (IllegalArgumentException ex) {
       response
           .getWriter()
-          .write(objectMapper.writeValueAsString(ErrorResponse.from(TokenErrorSpec.INVALID_TOKEN)));
+          .write(objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.AUTH_FAIL)));
     }
-    // 기타
-    response
-        .getWriter()
-        .write(objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.AUTH_FAIL)));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
@@ -1,8 +1,14 @@
 package com.heartsave.todaktodak_api.common.security.component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
+import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
+import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
+import com.heartsave.todaktodak_api.common.security.constant.JwtConstant;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -10,7 +16,9 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+  private final ObjectMapper objectMapper;
 
   @Override
   public void commence(
@@ -18,11 +26,23 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
       HttpServletResponse response,
       AuthenticationException authException)
       throws IOException {
-    setResponseWithMessage(response);
+    setResponseWithMessage(response, authException);
   }
 
-  private void setResponseWithMessage(HttpServletResponse response) throws IOException {
+  private void setResponseWithMessage(HttpServletResponse response, AuthenticationException e)
+      throws IOException {
     response.setStatus(HttpStatus.UNAUTHORIZED.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+    // 비정상 인증 토큰
+    if (e.getMessage().equals(JwtConstant.INVALID_TOKEN_ERROR_DETAIL)) {
+      response
+          .getWriter()
+          .write(objectMapper.writeValueAsString(ErrorResponse.from(TokenErrorSpec.INVALID_TOKEN)));
+    }
+    // 기타
+    response
+        .getWriter()
+        .write(objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.AUTH_FAIL)));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
@@ -1,13 +1,11 @@
 package com.heartsave.todaktodak_api.common.security.component;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
@@ -19,20 +17,12 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
       HttpServletRequest request,
       HttpServletResponse response,
       AuthenticationException authException)
-      throws IOException, ServletException {
-    var message = getMessage(authException);
-    setResponseWithMessage(response, message);
-  }
-
-  private String getMessage(AuthenticationException e) {
-    if (e instanceof UsernameNotFoundException) return "USER NOT FOUND";
-    return "UNEXPECTED ERROR";
-  }
-
-  private void setResponseWithMessage(HttpServletResponse response, String message)
       throws IOException {
+    setResponseWithMessage(response);
+  }
+
+  private void setResponseWithMessage(HttpServletResponse response) throws IOException {
     response.setStatus(HttpStatus.UNAUTHORIZED.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-    response.getWriter().write(message);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -32,6 +32,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtValidationFilter extends OncePerRequestFilter {
   private final ObjectMapper objectMapper;
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final String LOGIN_URL = "/api/v1/auth/login";
 
   @Override
   protected void doFilterInternal(
@@ -65,6 +66,11 @@ public class JwtValidationFilter extends OncePerRequestFilter {
       setErrorResponse(response, TokenErrorSpec.INVALID_TOKEN);
     }
     filterChain.doFilter(request, response);
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    return request.getServletPath().equals(LOGIN_URL);
   }
 
   private void setErrorResponse(HttpServletResponse response, TokenErrorSpec errorSpec)

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -4,6 +4,7 @@ import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.
 import static com.heartsave.todaktodak_api.common.security.util.JwtUtils.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -46,16 +47,18 @@ public class JwtValidationFilter extends OncePerRequestFilter {
       JwtUtils.extractAllClaims(token);
       if (!isValidTokenType(token)) {
         logger.error("유효하지 않은 토큰 유형입니다. {}", token);
-        throw new AuthenticationException(INVALID_TOKEN_ERROR_DETAIL);
+        throw new AuthenticationException(TokenErrorSpec.INVALID_TOKEN.name());
       }
       setAuthentication(token);
     } catch (ExpiredJwtException e) {
       logger.error("토큰이 만료됐습니다. {}", token);
+      throw new AuthenticationException(TokenErrorSpec.EXPIRED_TOKEN.name());
     } catch (SecurityException
         | MalformedJwtException
         | UnsupportedJwtException
         | IllegalArgumentException e) {
       logger.error("유효하지 않은 토큰입니다. {}", token);
+      throw new AuthenticationException(TokenErrorSpec.INVALID_TOKEN.name());
     }
     filterChain.doFilter(request, response);
   }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -11,6 +11,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.Nullable;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -73,17 +74,13 @@ public class JwtValidationFilter extends OncePerRequestFilter {
     if (request.getCookies() != null
         && Arrays.stream(request.getCookies())
             .anyMatch(p -> p.getName().equals(REFRESH_TOKEN_COOKIE_KEY))) {
-      if (request.getCookies() != null)
-        logger.warn(
-            String.valueOf(
-                Arrays.stream(request.getCookies())
-                    .anyMatch(p -> p.getName().equals(REFRESH_TOKEN_COOKIE_KEY))));
       request.setAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY, TokenErrorSpec.NON_EXISTENT_TOKEN);
     } else {
       request.setAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY, AuthErrorSpec.ABNORMAL_ACCESS);
     }
   }
 
+  @Nullable
   private String extractToken(HttpServletRequest request) {
     String value = request.getHeader(HEADER_KEY);
     if (value == null || !value.contains(TOKEN_PREFIX)) return null;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -6,7 +6,6 @@ import static com.heartsave.todaktodak_api.common.security.util.JwtUtils.*;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
 import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -42,42 +41,14 @@ public class JwtValidationFilter extends OncePerRequestFilter {
     var token = extractToken(request);
 
     if (token == null) {
-      setInvalidRequestAttribute(request);
+      setNoTokenRequestAttribute(request);
       filterChain.doFilter(request, response);
       return;
     }
-    try {
-      JwtUtils.extractAllClaims(token);
-      if (!isValidTokenType(token)) {
-        logger.error("유효하지 않은 토큰 유형입니다. {}", token);
-        authenticationEntryPoint.commence(
-            request, response, new BadCredentialsException(TokenErrorSpec.INVALID_TOKEN.name()));
-      } else {
-        setAuthentication(token);
-        filterChain.doFilter(request, response);
-      }
-    } catch (ExpiredJwtException e) {
-      logger.error("토큰이 만료됐습니다. {}", token);
-      authenticationEntryPoint.commence(
-          request, response, new BadCredentialsException(TokenErrorSpec.EXPIRED_TOKEN.name()));
-    } catch (SecurityException
-        | MalformedJwtException
-        | UnsupportedJwtException
-        | IllegalArgumentException e) {
-      logger.error("유효하지 않은 토큰입니다. {}", token);
-      authenticationEntryPoint.commence(
-          request, response, new BadCredentialsException(TokenErrorSpec.INVALID_TOKEN.name()));
-    }
-  }
 
-  private void setInvalidRequestAttribute(HttpServletRequest request) {
-    if (request.getCookies() != null
-        && Arrays.stream(request.getCookies())
-            .anyMatch(p -> p.getName().equals(REFRESH_TOKEN_COOKIE_KEY))) {
-      request.setAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY, TokenErrorSpec.NON_EXISTENT_TOKEN);
-    } else {
-      request.setAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY, AuthErrorSpec.ABNORMAL_ACCESS);
-    }
+    if (!validateTokenAndProcess(token, request, response)) return;
+    setAuthentication(token);
+    filterChain.doFilter(request, response);
   }
 
   @Nullable
@@ -87,8 +58,52 @@ public class JwtValidationFilter extends OncePerRequestFilter {
     return value.substring(TOKEN_PREFIX.length());
   }
 
-  private boolean isValidTokenType(String token) {
-    return JwtUtils.extractType(token).equals(ACCESS_TYPE);
+  private void setNoTokenRequestAttribute(HttpServletRequest request) {
+    if (existRefreshTokenCookie(request)) {
+      request.setAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY, TokenErrorSpec.NON_EXISTENT_TOKEN);
+    } else {
+      request.setAttribute(NO_TOKEN_REQUEST_ATTRIBUTE_KEY, AuthErrorSpec.ABNORMAL_ACCESS);
+    }
+  }
+
+  private boolean existRefreshTokenCookie(HttpServletRequest request) {
+    return request.getCookies() != null
+        && Arrays.stream(request.getCookies())
+            .anyMatch(p -> p.getName().equals(REFRESH_TOKEN_COOKIE_KEY));
+  }
+
+  private boolean validateTokenAndProcess(
+      String token, HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    try {
+      extractAllClaims(token);
+      if (!isAccessTokenType(token)) {
+        logger.error("유효하지 않은 토큰 유형입니다. {}", token);
+        respondAuthError(request, response, TokenErrorSpec.INVALID_TOKEN.name());
+        return false;
+      }
+      return true;
+    } catch (ExpiredJwtException e) {
+      logger.error("토큰이 만료됐습니다. {}", token);
+      respondAuthError(request, response, TokenErrorSpec.EXPIRED_TOKEN.name());
+    } catch (SecurityException
+        | MalformedJwtException
+        | UnsupportedJwtException
+        | IllegalArgumentException e) {
+      logger.error("유효하지 않은 토큰입니다. {}", token);
+      respondAuthError(request, response, TokenErrorSpec.INVALID_TOKEN.name());
+    }
+    return false;
+  }
+
+  private boolean isAccessTokenType(String token) {
+    return extractType(token).equals(ACCESS_TYPE);
+  }
+
+  private void respondAuthError(
+      HttpServletRequest request, HttpServletResponse response, String errorMessage)
+      throws ServletException, IOException {
+    authenticationEntryPoint.commence(request, response, new BadCredentialsException(errorMessage));
   }
 
   private void setAuthentication(String token) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -40,7 +40,7 @@ public class JwtValidationFilter extends OncePerRequestFilter {
     var token = extractToken(request);
 
     if (token == null) {
-      logger.error("NO TOKEN: {}", token);
+      setErrorResponse(response, TokenErrorSpec.NON_EXISTENT_TOKEN);
       filterChain.doFilter(request, response);
       return;
     }
@@ -64,6 +64,7 @@ public class JwtValidationFilter extends OncePerRequestFilter {
       logger.error("유효하지 않은 토큰입니다.");
       setErrorResponse(response, TokenErrorSpec.INVALID_TOKEN);
     }
+    filterChain.doFilter(request, response);
   }
 
   private void setErrorResponse(HttpServletResponse response, TokenErrorSpec errorSpec)

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
@@ -46,6 +46,11 @@ public class SecurityConfig {
       HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
     return http.csrf(AbstractHttpConfigurer::disable)
         .cors((cors) -> cors.configurationSource(corsConfigurationSource()))
+        .anonymous(AbstractHttpConfigurer::disable)
+        .exceptionHandling(
+            (eh) ->
+                eh.authenticationEntryPoint(authenticationEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler))
         .httpBasic(AbstractHttpConfigurer::disable)
         .oauth2Login(
             (oauth2) ->
@@ -53,10 +58,6 @@ public class SecurityConfig {
                     .userInfoEndpoint((config) -> config.userService(oauth2UserDetailsService))
                     .successHandler(oAuth2SuccessHandler)
                     .failureHandler(oauth2FailureHandler))
-        .exceptionHandling(
-            (eh) ->
-                eh.authenticationEntryPoint(authenticationEntryPoint)
-                    .accessDeniedHandler(accessDeniedHandler))
         .authorizeHttpRequests(
             authorize ->
                 authorize
@@ -67,8 +68,7 @@ public class SecurityConfig {
         .sessionManagement(
             sessionManagement ->
                 sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .addFilterBefore(
-            new JwtValidationFilter(objectMapper, authenticationEntryPoint), JwtAuthFilter.class)
+        .addFilterBefore(new JwtValidationFilter(authenticationEntryPoint), JwtAuthFilter.class)
         .addFilterBefore(
             new JwtAuthFilter(authenticationManager, objectMapper),
             UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.heartsave.todaktodak_api.common.security.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.heartsave.todaktodak_api.common.security.TodakUserDetailsService;
 import com.heartsave.todaktodak_api.common.security.component.AccessDeniedHandlerImpl;
 import com.heartsave.todaktodak_api.common.security.component.AuthenticationEntryPointImpl;
 import com.heartsave.todaktodak_api.common.security.component.jwt.JwtAuthFilter;
@@ -35,7 +34,6 @@ public class SecurityConfig {
   private final AccessDeniedHandlerImpl accessDeniedHandler;
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
   private final Oauth2FailureHandler oauth2FailureHandler;
-  private final TodakUserDetailsService userDetailsService;
   private final TodakOauth2UserDetailsService oauth2UserDetailsService;
   private final JwtLogoutFilter jwtLogoutFilter;
   private final ObjectMapper objectMapper;
@@ -48,18 +46,17 @@ public class SecurityConfig {
       HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
     return http.csrf(AbstractHttpConfigurer::disable)
         .cors((cors) -> cors.configurationSource(corsConfigurationSource()))
-        .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
-        .exceptionHandling(
-            (eh) ->
-                eh.authenticationEntryPoint(authenticationEntryPoint)
-                    .accessDeniedHandler(accessDeniedHandler))
         .oauth2Login(
             (oauth2) ->
                 oauth2
                     .userInfoEndpoint((config) -> config.userService(oauth2UserDetailsService))
                     .successHandler(oAuth2SuccessHandler)
                     .failureHandler(oauth2FailureHandler))
+        .exceptionHandling(
+            (eh) ->
+                eh.authenticationEntryPoint(authenticationEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler))
         .authorizeHttpRequests(
             authorize ->
                 authorize
@@ -70,7 +67,8 @@ public class SecurityConfig {
         .sessionManagement(
             sessionManagement ->
                 sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .addFilterBefore(new JwtValidationFilter(objectMapper), JwtAuthFilter.class)
+        .addFilterBefore(
+            new JwtValidationFilter(objectMapper, authenticationEntryPoint), JwtAuthFilter.class)
         .addFilterBefore(
             new JwtAuthFilter(authenticationManager, objectMapper),
             UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/constant/JwtConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/constant/JwtConstant.java
@@ -6,5 +6,4 @@ public class JwtConstant {
   public static final String TOKEN_PREFIX = "Bearer ";
   public static final String HEADER_KEY = "Authorization";
   public static final String REFRESH_TOKEN_COOKIE_KEY = "refresh_token";
-  public static final String INVALID_TOKEN_ERROR_DETAIL = "INVALID TOKEN ERROR";
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/constant/JwtConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/constant/JwtConstant.java
@@ -6,4 +6,5 @@ public class JwtConstant {
   public static final String TOKEN_PREFIX = "Bearer ";
   public static final String HEADER_KEY = "Authorization";
   public static final String REFRESH_TOKEN_COOKIE_KEY = "refresh_token";
+  public static final String NO_TOKEN_REQUEST_ATTRIBUTE_KEY = "NO-TOKEN";
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/constant/JwtConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/constant/JwtConstant.java
@@ -6,4 +6,5 @@ public class JwtConstant {
   public static final String TOKEN_PREFIX = "Bearer ";
   public static final String HEADER_KEY = "Authorization";
   public static final String REFRESH_TOKEN_COOKIE_KEY = "refresh_token";
+  public static final String INVALID_TOKEN_ERROR_DETAIL = "INVALID TOKEN ERROR";
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/domain/TodakUser.java
@@ -17,7 +17,7 @@ public class TodakUser implements UserDetails, OAuth2User, Serializable {
   private final String username;
   private final String role;
   private final Map<String, Object> attributes;
-  private String password;
+  private final String password;
 
   @Builder
   private TodakUser(


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

## 토큰 유효성 검사 실패에 대한 에러 응답 세분화
다음 로직으로 동작합니다.

1. HTTP 헤더에서 액세스 토큰 추출
    1. **액세스 토큰이 존재하지 않는 경우**
        1. **리프레시 토큰 쿠키가 존재: 토큰 재발급해야함을 응답**
        2. **리프레시 토큰 쿠키도 없음: 비정상 접근 간주**
2. 유효성 검사
    1. **만료: 로그인 재시도해야함을 응답토큰 위조된 경우: 비정상 접근 간주**

## 토큰 재발급

다음 로직으로 동작합니다.

1. 쿠키에서 리프레시 토큰 추출
    1. **쿠키가 없거나 리프로세 토큰이 존재하지 않는 경우: 비정상 접근 간주**
2. 유효성 검사
    1. **만료: 로그인 재시도해야함을 응답**
    2. **토큰 위조된 경우: 비정상 접근 간주**
3. 재발급을 위한 인증 정보(`TodakUser`) 생성
    1. **페이로드의 PK ID로 DB 조회**
    2. **존재하지 않는 ID: 비정상 에러로 판단**
4. 토큰 재발급
    1. **액세스 토큰: http body**
    2. **리프레시 토큰: 쿠키**

## AuthenticationEntryPoint

토큰 유효성 검사가 실패되면,
`JwtValidationFilter`가 `EntryPoint`를 실행하여 에러 응답을 해줍니다.

이때, **액세스 토큰이 없는 상황**에서
1) 비정상 접근
2) 새로고침으로 인해 토큰이 초기화된 인증된 회원

**두 Actor를 구분하기 위한
`HttpServletRequest`의 `attribute`를 추가하게 됩니다. (일종의 표식) (`JwtConstant`에서 attribute의 key를 확인할 수 있습니다.)**

## TODO
**1. 인증 API 및 객체에 대한 테스트 코드 작성
2.회원 API 개발**
둘 중 하나를 진행하겠습니다 😃

## 리뷰 받고 싶은 내용

-

## 테스트 및 결과
로컬 테스트 완료--

## 관련 스크린샷 및 참고자료 (Optional)
[스프링 시큐리티 인증, 인가 에러에 대한 고찰](https://github.com/kakaotech-19/todaktodak-api/wiki/%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0-%EC%9D%B8%EC%A6%9D,-%EC%9D%B8%EA%B0%80-%EC%97%90%EB%9F%AC%EC%97%90-%EB%8C%80%ED%95%9C-%EA%B3%A0%EC%B0%B0)

close #58 