### PR TITLE
refactor: 나의 일기 상세 조회시 Reaction 정보 제공 기능 삭제 TODAK-184

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryResponse.java
@@ -1,9 +1,9 @@
 package com.heartsave.todaktodak_api.diary.dto.response;
 
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,17 +21,14 @@ public class DiaryResponse {
   @Schema(description = "일기 내용", example = "오늘은 정말 좋은 하루였다...")
   private String content;
 
-  @Schema(description = "웹툰 이미지 URL", example = "https://example.com/webtoon/123.jpg")
-  private String webtoonImageUrl;
+  @Schema(description = "웹툰 이미지 URL", example = "[https://example.com/webtoon/123.jpg],[...]")
+  private List<String> webtoonImageUrls;
 
   @Schema(description = "배경음악 URL", example = "https://example.com/music/123.mp3")
   private String bgmUrl;
 
   @Schema(description = "AI가 작성한 코멘트", example = "오늘 하루도 수고 많으셨어요!")
   private String aiComment;
-
-  @Schema(description = "일기에 대한 반응 수 정보")
-  private DiaryReactionCountProjection reactionCount;
 
   @Schema(description = "일기 작성 날짜", example = "2024-10-26", type = "string", format = "date")
   private LocalDate date;


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 사용자가 private한 나의 일기 상세 조회시에 ```Reaction```은 제공 되지 않습니다.
- 나의 일기 상세 조회시 s3의 pre-sigend 로직을 추가하였습니다.
- 추후 나의 공개 일기 조회시, ```Reaction``` 정보를 제공할 예정입니다.

## 리뷰 받고 싶은 내용
- 로직의 큰 변화는 없습니다! ```diff```도 많지 않지만, 혹시 제가 놓친 부분이 있다면 알려주시면 감사하겠습니다. :)

## 테스트 및 결과
- 로컬 테스트 통과 확인하였습니다.

## 관련 스크린샷 및 참고자료 (Optional)

close #62 