### PR TITLE
Feature/todak 211/diary writing blank url

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/ai/service/AiService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/service/AiService.java
@@ -26,11 +26,11 @@ public class AiService {
   private final WebClient webClient;
 
   public AiContentResponse callAiContent(DiaryEntity diary) {
-    //    AiContentRequest request = getAiContentRequest(diary);
-    //    callWebtoon(request);
-    //    callBgm(request);
-    //    String comment = callComment(request);
-    return AiContentResponse.builder().aiComment("aiComment").build();
+    AiContentRequest request = getAiContentRequest(diary);
+    callWebtoon(request);
+    callBgm(request);
+    String comment = callComment(request);
+    return AiContentResponse.builder().aiComment(comment).build();
   }
 
   private AiContentRequest getAiContentRequest(DiaryEntity diary) {

--- a/src/main/java/com/heartsave/todaktodak_api/ai/service/AiService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/service/AiService.java
@@ -26,11 +26,11 @@ public class AiService {
   private final WebClient webClient;
 
   public AiContentResponse callAiContent(DiaryEntity diary) {
-    AiContentRequest request = getAiContentRequest(diary);
-    callWebtoon(request);
-    callBgm(request);
-    String comment = callComment(request);
-    return AiContentResponse.builder().aiComment(comment).build();
+    //    AiContentRequest request = getAiContentRequest(diary);
+    //    callWebtoon(request);
+    //    callBgm(request);
+    //    String comment = callComment(request);
+    return AiContentResponse.builder().aiComment("aiComment").build();
   }
 
   private AiContentRequest getAiContentRequest(DiaryEntity diary) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
@@ -1,0 +1,11 @@
+package com.heartsave.todaktodak_api.common.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CoreConstant {
+  public static class URL {
+    public static final String DEFAULT_URL = "";
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageService.java
@@ -1,9 +1,12 @@
 package com.heartsave.todaktodak_api.common.storage;
 
+import static com.heartsave.todaktodak_api.common.constant.CoreConstant.URL.DEFAULT_URL;
+
 import com.heartsave.todaktodak_api.common.config.properties.S3Properties;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -11,6 +14,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @RequiredArgsConstructor
+@Slf4j
 @Service
 public class S3FileStorageService {
   private final S3Presigner s3Presigner;
@@ -22,6 +26,8 @@ public class S3FileStorageService {
   }
 
   public String preSignedFirstWebtoonUrlFrom(String key) {
+    log.info("this is key = {}", key);
+    log.info("this is key = {}", s3Properties.defaultKey().webtoon());
     return key == null ? preSign(s3Properties.defaultKey().webtoon()) : preSign(key);
   }
 
@@ -35,6 +41,8 @@ public class S3FileStorageService {
 
   // TODO: presigned url 캐싱 관리
   private String preSign(String key) throws NoSuchKeyException {
+    if (key.equals(DEFAULT_URL)) return DEFAULT_URL;
+
     var preSignRequest =
         GetObjectPresignRequest.builder()
             .signatureDuration(Duration.ofSeconds(s3Properties.presignDuration()))

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageService.java
@@ -26,8 +26,6 @@ public class S3FileStorageService {
   }
 
   public String preSignedFirstWebtoonUrlFrom(String key) {
-    log.info("this is key = {}", key);
-    log.info("this is key = {}", s3Properties.defaultKey().webtoon());
     return key == null ? preSign(s3Properties.defaultKey().webtoon()) : preSign(key);
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -1,5 +1,7 @@
 package com.heartsave.todaktodak_api.diary.service;
 
+import static com.heartsave.todaktodak_api.common.constant.CoreConstant.URL.DEFAULT_URL;
+
 import com.heartsave.todaktodak_api.ai.dto.response.AiContentResponse;
 import com.heartsave.todaktodak_api.ai.service.AiService;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
@@ -120,6 +122,8 @@ public class DiaryService {
         .emotion(request.getEmotion())
         .content(request.getContent())
         .diaryCreatedTime((request.getDate()))
+        .webtoonImageUrl(DEFAULT_URL)
+        .bgmUrl(DEFAULT_URL)
         .build();
   }
 }


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항
### 문제점
- 기존에는 사용자가 일기 작성을 하면 DB에는 URL 정보를 ```NULL```로 설정합니다.
- 하지만 AI 컨텐츠가 생성되는 동안 일기 정보를 ```Repository```에서 꺼내게 되면 ```NULL```로 받아온 상태에서,
```Projection```의 생성자에 의해 ```List.of()```가 실행되고, ```NPE```이 발생합니다. 
### 해결방법
이에 따라, ```DEFAULT_URL=""```이라는 상수를 만들어 일기 생성시 넣어주어 ```NPE```를 방지하고 빈 값을 API로 응답합니다.

## 리뷰 받고 싶은 내용

- ```DEFAULT_URL``` 상수 대신에 설정해주신 S3의 기본 URL(Webtoon, Bgm, Character)을 넣으려고 했으나, 웹툰과 BGM의 경우 기본 URL을 제공하게 되면, 사용자에게 AI 컨텐츠가 생성되지 않았다는 것을 명확하게 알려주기가 어려울 것으로 판단되어 빈 문자열 ```""```을 넣었습니다.
- 혹시 다른 의견 있으시면 편하게 알려주세요!

## 테스트 및 결과
- 로컬 테스트 확인 완료

## 관련 스크린샷 및 참고자료 (Optional)

close #85  