### PR TITLE
Feature/todak 214/diary webhook bgm

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookController.java
@@ -4,6 +4,8 @@ import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiBgmRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import com.heartsave.todaktodak_api.ai.webhook.service.AiDiaryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,14 +28,21 @@ public class AiWebhookController {
 
   private final AiDiaryService aiDiaryService;
 
-  @Operation(summary = "AI 웹툰 저장")
+  @Operation(summary = "AI 웹툰 저장", description = "AI가 생성한 웹툰을 저장합니다.")
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "204", description = "AI 웹툰 저장 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청")
       })
   @PostMapping("/webtoon")
-  public ResponseEntity<Void> saveWebtoon(@Valid @RequestBody AiWebtoonRequest request) {
+  public ResponseEntity<Void> saveWebtoon(
+      @Parameter(
+              description = "AI 웹툰 저장 요청 정보",
+              required = true,
+              schema = @Schema(implementation = AiWebtoonRequest.class))
+          @Valid
+          @RequestBody
+          AiWebtoonRequest request) {
     log.info(
         "AI 웹툰 저장을 시작합니다. memberId={}, diaryDate={}", request.memberId(), request.createdDate());
     aiDiaryService.saveWebtoon(request);
@@ -42,8 +51,21 @@ public class AiWebhookController {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
+  @Operation(summary = "AI BGM 저장", description = "AI가 생성한 BGM을 저장합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "AI BGM 저장 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청")
+      })
   @PostMapping("/bgm")
-  public ResponseEntity<Void> saveBgm(@Valid @RequestBody AiBgmRequest request) {
+  public ResponseEntity<Void> saveBgm(
+      @Parameter(
+              description = "AI BGM 저장 요청 정보",
+              required = true,
+              schema = @Schema(implementation = AiBgmRequest.class))
+          @Valid
+          @RequestBody
+          AiBgmRequest request) {
     log.info(
         "AI BGM 저장을 시작합니다. memberId={}, diaryDate={}", request.memberId(), request.createdDate());
     aiDiaryService.saveBgm(request);

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookController.java
@@ -44,7 +44,11 @@ public class AiWebhookController {
 
   @PostMapping("/bgm")
   public ResponseEntity<Void> saveBgm(@Valid @RequestBody AiBgmRequest request) {
+    log.info(
+        "AI BGM 저장을 시작합니다. memberId={}, diaryDate={}", request.memberId(), request.createdDate());
     aiDiaryService.saveBgm(request);
+    log.info(
+        "AI BGM 저장을 마칩니다. memberId={}, diaryDate={}", request.memberId(), request.createdDate());
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookController.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.ai.webhook.controller;
 
+import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiBgmRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import com.heartsave.todaktodak_api.ai.webhook.service.AiDiaryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,6 +39,12 @@ public class AiWebhookController {
     aiDiaryService.saveWebtoon(request);
     log.info(
         "AI 웹툰 저장을 마침니다. memberId={}, diaryDate={}", request.memberId(), request.createdDate());
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @PostMapping("/bgm")
+  public ResponseEntity<Void> saveBgm(@Valid @RequestBody AiBgmRequest request) {
+    aiDiaryService.saveBgm(request);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/AiBgmRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/AiBgmRequest.java
@@ -1,0 +1,13 @@
+package com.heartsave.todaktodak_api.ai.webhook.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record AiBgmRequest(
+    @NotNull @Min(1L) Long memberId,
+    @NotNull @DateTimeFormat(pattern = "yyyy-MM-dd") @JsonProperty("date") LocalDate createdDate,
+    @NotBlank String bgmUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/AiBgmRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/AiBgmRequest.java
@@ -1,13 +1,19 @@
 package com.heartsave.todaktodak_api.ai.webhook.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
+@Schema(description = "AI BGM 저장 요청 데이터")
 public record AiBgmRequest(
-    @NotNull @Min(1L) Long memberId,
-    @NotNull @DateTimeFormat(pattern = "yyyy-MM-dd") @JsonProperty("date") LocalDate createdDate,
-    @NotBlank String bgmUrl) {}
+    @Schema(description = "회원 ID", example = "1", minimum = "1") @NotNull @Min(1L) Long memberId,
+    @Schema(description = "일기 작성 날짜", example = "2024-11-06", format = "yyyy-MM-dd")
+        @NotNull
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @JsonProperty("date")
+        LocalDate createdDate,
+    @Schema(description = "BGM 파일 URL", example = "/bgm/1/2024/11/06") @NotBlank String bgmUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/AiWebtoonRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/AiWebtoonRequest.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.ai.webhook.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -13,6 +14,7 @@ public record AiWebtoonRequest(
     @Schema(description = "일기 작성 날짜", example = "2024-11-06", format = "yyyy-MM-dd")
         @NotNull
         @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @JsonProperty("date")
         LocalDate createdDate,
     @Schema(description = "웹툰 폴더 URL", example = "/webtoon/1/2024/11/06") @NotBlank
         String webtoonFolderUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiJpaRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiJpaRepository.java
@@ -1,0 +1,36 @@
+package com.heartsave.todaktodak_api.ai.webhook.repository;
+
+import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AiJpaRepository extends JpaRepository<DiaryEntity, Long> {
+  @Modifying
+  @Query(
+      value =
+          """
+        UPDATE DiaryEntity d
+        SET d.webtoonImageUrl = :url
+        WHERE d.memberEntity.id = :memberId AND  CAST(d.diaryCreatedTime AS DATE ) = :createdDate
+""")
+  int updateWebtoonUrl(
+      @Param("memberId") Long memberId,
+      @Param("createdDate") LocalDate createdDate,
+      @Param("url") String url);
+
+  @Query(
+      value =
+          """
+        SELECT
+        CASE WHEN d.bgmUrl != "" AND d.webtoonImageUrl != "" THEN TRUE
+        ELSE FALSE END
+        FROM DiaryEntity d
+        WHERE d.memberEntity.id = :memberId AND CAST(d.diaryCreatedTime AS DATE) = :createdDate
+""")
+  Optional<Boolean> isContentCompleted(
+      @Param("memberId") Long memberId, @Param("createdDate") LocalDate createdDate);
+}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiJpaRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiJpaRepository.java
@@ -22,6 +22,19 @@ public interface AiJpaRepository extends JpaRepository<DiaryEntity, Long> {
       @Param("createdDate") LocalDate createdDate,
       @Param("url") String url);
 
+  @Modifying
+  @Query(
+      value =
+          """
+                UPDATE DiaryEntity d
+                SET d.bgmUrl = :url
+                WHERE d.memberEntity.id = :memberId AND  CAST(d.diaryCreatedTime AS DATE ) = :createdDate
+        """)
+  int updateBgmUrl(
+      @Param("memberId") Long memberId,
+      @Param("createdDate") LocalDate createdDate,
+      @Param("url") String url);
+
   @Query(
       value =
           """

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepository.java
@@ -1,36 +1,22 @@
 package com.heartsave.todaktodak_api.ai.webhook.repository;
 
-import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
+import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import java.time.LocalDate;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
-public interface AiRepository extends JpaRepository<DiaryEntity, Long> {
-  @Modifying
-  @Query(
-      value =
-          """
-        UPDATE DiaryEntity d
-        SET d.webtoonImageUrl = :url
-        WHERE d.memberEntity.id = :memberId AND  CAST(d.diaryCreatedTime AS DATE ) = :createdDate
-""")
-  int updateWebtoonUrl(
-      @Param("memberId") Long memberId,
-      @Param("createdDate") LocalDate createdDate,
-      @Param("url") String url);
+@RequiredArgsConstructor
+@Repository
+public class AiRepository {
 
-  @Query(
-      value =
-          """
-        SELECT
-        CASE WHEN d.bgmUrl != "" AND d.webtoonImageUrl != "" THEN TRUE
-        ELSE FALSE END
-        FROM DiaryEntity d
-        WHERE d.memberEntity.id = :memberId AND CAST(d.diaryCreatedTime AS DATE) = :createdDate
-""")
-  Optional<Boolean> isContentCompleted(
-      @Param("memberId") Long memberId, @Param("createdDate") LocalDate createdDate);
+  private final AiJpaRepository jpaRepository;
+
+  public int updateWebtoonUrl(AiWebtoonRequest request) {
+    return jpaRepository.updateWebtoonUrl(
+        request.memberId(), request.createdDate(), request.webtoonFolderUrl());
+  }
+
+  public Boolean isContentCompleted(Long memberId, LocalDate createdDate) {
+    return jpaRepository.isContentCompleted(memberId, createdDate).orElse(false);
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepository.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.ai.webhook.repository;
 
+import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiBgmRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,10 @@ public class AiRepository {
   public int updateWebtoonUrl(AiWebtoonRequest request) {
     return jpaRepository.updateWebtoonUrl(
         request.memberId(), request.createdDate(), request.webtoonFolderUrl());
+  }
+
+  public int updateBgmUrl(AiBgmRequest request) {
+    return jpaRepository.updateBgmUrl(request.memberId(), request.createdDate(), request.bgmUrl());
   }
 
   public Boolean isContentCompleted(Long memberId, LocalDate createdDate) {

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.ai.webhook.service;
 
+import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiBgmRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
 import java.time.LocalDate;
@@ -20,6 +21,19 @@ public class AiDiaryService {
     int result = aiRepository.updateWebtoonUrl(request);
     if (result == 0) {
       log.warn("Webtoon Url을 업데이트 할 일기가 없습니다. memberId={}, diaryDate={}", memberId, createdDate);
+      return;
+    }
+    if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
+      // Todo : SSE 알림 구현
+    }
+  }
+
+  public void saveBgm(AiBgmRequest request) {
+    Long memberId = request.memberId();
+    LocalDate createdDate = request.createdDate();
+    int result = aiRepository.updateBgmUrl(request);
+    if (result == 0) {
+      log.warn("bgm Url을 업데이트 할 일기가 없습니다. memberId={}, diaryDate={}", memberId, createdDate);
       return;
     }
     if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
@@ -18,11 +18,13 @@ public class AiDiaryService {
   public void saveWebtoon(AiWebtoonRequest request) {
     Long memberId = request.memberId();
     LocalDate createdDate = request.createdDate();
+    log.info("webtoon url 업데이트를 시작합니다.");
     int result = aiRepository.updateWebtoonUrl(request);
     if (result == 0) {
       log.warn("Webtoon Url을 업데이트 할 일기가 없습니다. memberId={}, diaryDate={}", memberId, createdDate);
       return;
     }
+    log.info("webtoon url 업데이트를 마쳤습니다.");
     if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
       // Todo : SSE 알림 구현
     }
@@ -31,11 +33,14 @@ public class AiDiaryService {
   public void saveBgm(AiBgmRequest request) {
     Long memberId = request.memberId();
     LocalDate createdDate = request.createdDate();
+
+    log.info("Bgm url 업데이트를 시작합니다. memberId={}", memberId);
     int result = aiRepository.updateBgmUrl(request);
     if (result == 0) {
       log.warn("bgm Url을 업데이트 할 일기가 없습니다. memberId={}, diaryDate={}", memberId, createdDate);
       return;
     }
+    log.info("Bgm url 업데이트를 마쳤습니다. memberId={}", memberId);
     if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
       // Todo : SSE 알림 구현
     }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
@@ -17,14 +17,12 @@ public class AiDiaryService {
   public void saveWebtoon(AiWebtoonRequest request) {
     Long memberId = request.memberId();
     LocalDate createdDate = request.createdDate();
-    int result = aiRepository.updateWebtoonUrl(memberId, createdDate, request.webtoonFolderUrl());
+    int result = aiRepository.updateWebtoonUrl(request);
     if (result == 0) {
       log.warn("Webtoon Url을 업데이트 할 일기가 없습니다. memberId={}, diaryDate={}", memberId, createdDate);
       return;
     }
-    if (aiRepository
-        .isContentCompleted(memberId, createdDate)
-        .orElse(false)) { // Todo : Lock 설정을 통한 동시성 통제
+    if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
       // Todo : SSE 알림 구현
     }
   }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
@@ -1,13 +1,16 @@
 package com.heartsave.todaktodak_api.ai.webhook.controller;
 
+import static com.heartsave.todaktodak_api.common.BaseTestObject.TEST_BGM_URL;
+import static com.heartsave.todaktodak_api.common.BaseTestObject.TEST_WEBTOON_URL;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiBgmRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import com.heartsave.todaktodak_api.ai.webhook.service.AiDiaryService;
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.config.WebConfig;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -44,8 +47,8 @@ class AiWebhookControllerTest {
 
   @BeforeEach
   void setup() {
-    member = BaseTestEntity.createMember();
-    diary = BaseTestEntity.createDiaryWithMember(member);
+    member = BaseTestObject.createMember();
+    diary = BaseTestObject.createDiaryWithMember(member);
   }
 
   @Nested
@@ -57,9 +60,7 @@ class AiWebhookControllerTest {
     void saveWebtoon_ValidRequest_Returns204() throws Exception {
       AiWebtoonRequest request =
           new AiWebtoonRequest(
-              member.getId(),
-              diary.getDiaryCreatedTime().toLocalDate(),
-              "http://example.com/webtoon/folder");
+              member.getId(), diary.getDiaryCreatedTime().toLocalDate(), TEST_WEBTOON_URL);
 
       doNothing().when(aiDiaryService).saveWebtoon(any(AiWebtoonRequest.class));
 
@@ -77,8 +78,7 @@ class AiWebhookControllerTest {
     @DisplayName("필수 파라미터가 누락된 경우 400 상태코드 반환")
     void saveWebtoon_InvalidRequest_Returns400() throws Exception {
       AiWebtoonRequest request =
-          new AiWebtoonRequest(
-              null, diary.getDiaryCreatedTime().toLocalDate(), "http://example.com/webtoon/folder");
+          new AiWebtoonRequest(null, diary.getDiaryCreatedTime().toLocalDate(), TEST_WEBTOON_URL);
 
       mockMvc
           .perform(
@@ -89,6 +89,86 @@ class AiWebhookControllerTest {
           .andExpect(status().isBadRequest());
 
       verify(aiDiaryService, never()).saveWebtoon(any(AiWebtoonRequest.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("AI BGM 생성 완료시 저장 API 테스트")
+  class SaveBgmTest {
+
+    @Test
+    @DisplayName("정상적인 요청의 경우 204 상태코드 반환")
+    void saveBgm_ValidRequest_Returns204() throws Exception {
+      AiBgmRequest request =
+          new AiBgmRequest(member.getId(), diary.getDiaryCreatedTime().toLocalDate(), TEST_BGM_URL);
+
+      doNothing().when(aiDiaryService).saveBgm(any(AiBgmRequest.class));
+
+      mockMvc
+          .perform(
+              post("/api/v1/webhook/ai/bgm")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isNoContent());
+
+      verify(aiDiaryService, times(1)).saveBgm(any(AiBgmRequest.class));
+    }
+
+    @Test
+    @DisplayName("필수 파라미터가 누락된 경우 400 상태코드 반환")
+    void saveBgm_InvalidRequest_Returns400() throws Exception {
+      AiBgmRequest request =
+          new AiBgmRequest(null, diary.getDiaryCreatedTime().toLocalDate(), TEST_BGM_URL);
+
+      mockMvc
+          .perform(
+              post("/api/v1/webhook/ai/bgm")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+                  .characterEncoding(StandardCharsets.UTF_8))
+          .andExpect(status().isBadRequest());
+
+      verify(aiDiaryService, never()).saveBgm(any(AiBgmRequest.class));
+    }
+
+    @Test
+    @DisplayName("BGM URL이 비어있는 경우 400 상태코드 반환")
+    void saveBgm_EmptyBgmUrl_Returns400() throws Exception {
+      AiBgmRequest request =
+          new AiBgmRequest(member.getId(), diary.getDiaryCreatedTime().toLocalDate(), "");
+
+      mockMvc
+          .perform(
+              post("/api/v1/webhook/ai/bgm")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+                  .characterEncoding(StandardCharsets.UTF_8))
+          .andExpect(status().isBadRequest());
+
+      verify(aiDiaryService, never()).saveBgm(any(AiBgmRequest.class));
+    }
+
+    @Test
+    @DisplayName("날짜 형식이 잘못된 경우 400 상태코드 반환")
+    void saveBgm_InvalidDateFormat_Returns400() throws Exception {
+      String requestBody =
+          """
+          {
+            "memberId": 1,
+            "date": "2024/11/06",
+            "bgmUrl": "music-ai/1/2024/11/06/bgm.mp3"
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/webhook/ai/bgm")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(requestBody)
+                  .characterEncoding(StandardCharsets.UTF_8))
+          .andExpect(status().isBadRequest());
+
+      verify(aiDiaryService, never()).saveBgm(any(AiBgmRequest.class));
     }
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiJpaRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiJpaRepositoryTest.java
@@ -3,6 +3,7 @@ package com.heartsave.todaktodak_api.ai.webhook.repository;
 import static com.heartsave.todaktodak_api.common.BaseTestEntity.DUMMY_STRING_CONTENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import com.heartsave.todaktodak_api.common.BaseTestEntity;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
@@ -17,10 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 
 @Slf4j
 @DataJpaTest
-class AiRepositoryTest {
+@Import(AiRepository.class)
+class AiJpaRepositoryTest {
 
   @Autowired private AiRepository aiRepository;
 
@@ -52,9 +55,10 @@ class AiRepositoryTest {
     @DisplayName("웹툰 URL을 성공적으로 업데이트")
     void updateWebtoonUrlSuccessfully() {
       String newUrl = "https://new-url/webtoon.jpg";
+      AiWebtoonRequest request =
+          new AiWebtoonRequest(member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newUrl);
 
-      aiRepository.updateWebtoonUrl(
-          member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newUrl);
+      aiRepository.updateWebtoonUrl(request);
 
       DiaryEntity updatedDiary = tem.find(DiaryEntity.class, diary.getId());
       assertThat(updatedDiary.getWebtoonImageUrl()).isEqualTo(newUrl);
@@ -65,8 +69,9 @@ class AiRepositoryTest {
     void updateWebtoonUrlWithNonExistentData() {
       String newUrl = "https://example.com/webtoon.jpg";
       LocalDate nonExistentDate = LocalDate.now().plusDays(1);
+      AiWebtoonRequest request = new AiWebtoonRequest(member.getId(), nonExistentDate, newUrl);
 
-      aiRepository.updateWebtoonUrl(member.getId(), nonExistentDate, newUrl);
+      aiRepository.updateWebtoonUrl(request);
 
       DiaryEntity unchangedDiary = tem.find(DiaryEntity.class, diary.getId());
       assertThat(unchangedDiary.getWebtoonImageUrl()).isEqualTo("");
@@ -81,9 +86,8 @@ class AiRepositoryTest {
     @DisplayName("bgmUrl과 webtoonImageUrl이 모두 빈 문자열이면 false를 반환한다")
     void returnsFalseWhenBothUrlsAreEmpty() {
       Boolean result =
-          aiRepository
-              .isContentCompleted(member.getId(), diary.getDiaryCreatedTime().toLocalDate())
-              .get();
+          aiRepository.isContentCompleted(
+              member.getId(), diary.getDiaryCreatedTime().toLocalDate());
 
       assertThat(result).isFalse();
     }
@@ -106,9 +110,8 @@ class AiRepositoryTest {
       tem.clear();
 
       Boolean result =
-          aiRepository
-              .isContentCompleted(member.getId(), diaryWithBgm.getDiaryCreatedTime().toLocalDate())
-              .get();
+          aiRepository.isContentCompleted(
+              member.getId(), diaryWithBgm.getDiaryCreatedTime().toLocalDate());
 
       assertThat(result).isFalse();
     }
@@ -131,10 +134,8 @@ class AiRepositoryTest {
       tem.clear();
 
       Boolean result =
-          aiRepository
-              .isContentCompleted(
-                  member.getId(), diaryWithWebtoon.getDiaryCreatedTime().toLocalDate())
-              .get();
+          aiRepository.isContentCompleted(
+              member.getId(), diaryWithWebtoon.getDiaryCreatedTime().toLocalDate());
 
       assertThat(result).isFalse();
     }
@@ -157,10 +158,8 @@ class AiRepositoryTest {
       tem.clear();
 
       Boolean result =
-          aiRepository
-              .isContentCompleted(
-                  member.getId(), completedDiary.getDiaryCreatedTime().toLocalDate())
-              .get();
+          aiRepository.isContentCompleted(
+              member.getId(), completedDiary.getDiaryCreatedTime().toLocalDate());
 
       assertThat(result).isTrue();
     }
@@ -170,8 +169,7 @@ class AiRepositoryTest {
     void returnsNullForNonExistentData() {
       LocalDate nonExistentDate = LocalDate.now().plusDays(1);
 
-      Boolean result =
-          aiRepository.isContentCompleted(member.getId(), nonExistentDate).orElse(false);
+      Boolean result = aiRepository.isContentCompleted(member.getId(), nonExistentDate);
 
       assertThat(result).isFalse();
     }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
@@ -1,8 +1,11 @@
 package com.heartsave.todaktodak_api.ai.webhook.service;
 
+import static com.heartsave.todaktodak_api.common.BaseTestObject.TEST_BGM_URL;
+import static com.heartsave.todaktodak_api.common.BaseTestObject.TEST_WEBTOON_URL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiBgmRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
 import java.time.LocalDate;
@@ -21,14 +24,15 @@ class AiDiaryServiceTest {
   @Mock private AiRepository aiRepository;
   @InjectMocks private AiDiaryService aiDiaryService;
 
-  private AiWebtoonRequest request;
+  private AiWebtoonRequest webtoonRequest;
+  private AiBgmRequest bgmRequest;
   private final Long memberId = 1L;
   private final LocalDate createdDate = LocalDate.now();
-  private final String webtoonUrl = "http://example.com/webtoon/folder";
 
   @BeforeEach
   void setUp() {
-    request = new AiWebtoonRequest(memberId, createdDate, webtoonUrl);
+    webtoonRequest = new AiWebtoonRequest(memberId, createdDate, TEST_WEBTOON_URL);
+    bgmRequest = new AiBgmRequest(memberId, createdDate, TEST_BGM_URL);
   }
 
   @Nested
@@ -38,24 +42,24 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("웹툰 URL 업데이트 성공 및 AI 컨텐츠 생성이 미완료된 경우")
     void saveWebtoon_UpdateSuccessAndAiContentCompleted() {
-      when(aiRepository.updateWebtoonUrl(request)).thenReturn(1);
+      when(aiRepository.updateWebtoonUrl(webtoonRequest)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(false);
 
-      aiDiaryService.saveWebtoon(request);
+      aiDiaryService.saveWebtoon(webtoonRequest);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(request);
+      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
     }
 
     @Test
     @DisplayName("웹툰 URL 업데이트 성공 및 AI 컨텐츠 생성이 완료된 경우")
     void saveWebtoon_UpdateSuccessAndCustomBgmUrl() {
-      when(aiRepository.updateWebtoonUrl(request)).thenReturn(1);
+      when(aiRepository.updateWebtoonUrl(webtoonRequest)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(true);
 
-      aiDiaryService.saveWebtoon(request);
+      aiDiaryService.saveWebtoon(webtoonRequest);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(request);
+      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
       // Todo: SSE 알림 관련 검증 추가 필요
     }
@@ -63,11 +67,52 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("업데이트할 일기가 없는 경우")
     void saveWebtoon_NoDataToUpdate() {
-      when(aiRepository.updateWebtoonUrl(request)).thenReturn(0);
+      when(aiRepository.updateWebtoonUrl(webtoonRequest)).thenReturn(0);
 
-      aiDiaryService.saveWebtoon(request);
+      aiDiaryService.saveWebtoon(webtoonRequest);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(request);
+      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest);
+      verify(aiRepository, never()).isContentCompleted(any(), any());
+    }
+  }
+
+  @Nested
+  @DisplayName("BGM URL 저장 테스트")
+  class SaveBgmTest {
+
+    @Test
+    @DisplayName("BGM URL 업데이트 성공 및 AI 컨텐츠 생성이 미완료된 경우")
+    void saveBgm_UpdateSuccessAndAiContentNotCompleted() {
+      when(aiRepository.updateBgmUrl(bgmRequest)).thenReturn(1);
+      when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(false);
+
+      aiDiaryService.saveBgm(bgmRequest);
+
+      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest);
+      verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
+    }
+
+    @Test
+    @DisplayName("BGM URL 업데이트 성공 및 AI 컨텐츠 생성이 완료된 경우")
+    void saveBgm_UpdateSuccessAndAiContentCompleted() {
+      when(aiRepository.updateBgmUrl(bgmRequest)).thenReturn(1);
+      when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(true);
+
+      aiDiaryService.saveBgm(bgmRequest);
+
+      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest);
+      verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
+      // Todo: SSE 알림 관련 검증 추가 필요
+    }
+
+    @Test
+    @DisplayName("업데이트할 일기가 없는 경우")
+    void saveBgm_NoDataToUpdate() {
+      when(aiRepository.updateBgmUrl(bgmRequest)).thenReturn(0);
+
+      aiDiaryService.saveBgm(bgmRequest);
+
+      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest);
       verify(aiRepository, never()).isContentCompleted(any(), any());
     }
   }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.AiWebtoonRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
 import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,24 +38,24 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("웹툰 URL 업데이트 성공 및 AI 컨텐츠 생성이 미완료된 경우")
     void saveWebtoon_UpdateSuccessAndAiContentCompleted() {
-      when(aiRepository.updateWebtoonUrl(memberId, createdDate, webtoonUrl)).thenReturn(1);
-      when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(Optional.of(false));
+      when(aiRepository.updateWebtoonUrl(request)).thenReturn(1);
+      when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(false);
 
       aiDiaryService.saveWebtoon(request);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(memberId, createdDate, webtoonUrl);
+      verify(aiRepository, times(1)).updateWebtoonUrl(request);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
     }
 
     @Test
     @DisplayName("웹툰 URL 업데이트 성공 및 AI 컨텐츠 생성이 완료된 경우")
     void saveWebtoon_UpdateSuccessAndCustomBgmUrl() {
-      when(aiRepository.updateWebtoonUrl(memberId, createdDate, webtoonUrl)).thenReturn(1);
-      when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(Optional.of(true));
+      when(aiRepository.updateWebtoonUrl(request)).thenReturn(1);
+      when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(true);
 
       aiDiaryService.saveWebtoon(request);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(memberId, createdDate, webtoonUrl);
+      verify(aiRepository, times(1)).updateWebtoonUrl(request);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
       // Todo: SSE 알림 관련 검증 추가 필요
     }
@@ -64,11 +63,11 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("업데이트할 일기가 없는 경우")
     void saveWebtoon_NoDataToUpdate() {
-      when(aiRepository.updateWebtoonUrl(memberId, createdDate, webtoonUrl)).thenReturn(0);
+      when(aiRepository.updateWebtoonUrl(request)).thenReturn(0);
 
       aiDiaryService.saveWebtoon(request);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(memberId, createdDate, webtoonUrl);
+      verify(aiRepository, times(1)).updateWebtoonUrl(request);
       verify(aiRepository, never()).isContentCompleted(any(), any());
     }
   }

--- a/src/test/java/com/heartsave/todaktodak_api/common/BaseTestObject.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/BaseTestObject.java
@@ -7,11 +7,13 @@ import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
-public class BaseTestEntity {
+public class BaseTestObject {
 
   public static final String DUMMY_STRING_CONTENT =
       "이렇게 한국말을 적으면 그래도 글자 수가 좀 더 많이 올라가지 않을까? 왜냐하면 더 많은 bit를 사용하기 때문이지 그러나 utf-8로 인코딩을 한다면 영어나 한글이나 같은 단위로 쪼개져 계산이 되기 때문에 어차피 비슷할 수 도 있겠구나 그렇다면 이제부터 무지성 영어를 눌러야겠다."
           + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb";
+  public static final String TEST_WEBTOON_URL = "webtoon/1/2024/11/06";
+  public static final String TEST_BGM_URL = "music-ai/1/2024/11/06/bgm.mp3";
   private static String TEST_LOGIN_ID = "TEST_LOGIN_ID";
   private static String TEST_PASSWORD = "TEST_PASSWORD";
   private static String TEST_EMAIL = "TEST_EMAIL@kakao.com";

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.security.WithMockTodakUser;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
@@ -57,7 +57,7 @@ public class DiaryControllerTest {
   void writeDiarySuccess() throws Exception {
     DiaryWriteRequest request =
         new DiaryWriteRequest(
-            LocalDateTime.now(), DiaryEmotion.HAPPY, BaseTestEntity.DUMMY_STRING_CONTENT);
+            LocalDateTime.now(), DiaryEmotion.HAPPY, BaseTestObject.DUMMY_STRING_CONTENT);
 
     final String AI_COMMENT = "this is test ai comment";
 

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryReactionRepositoryTest.java
@@ -3,7 +3,7 @@ package com.heartsave.todaktodak_api.diary.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.DiaryReactionEntity;
@@ -34,8 +34,8 @@ public class DiaryReactionRepositoryTest {
 
   @BeforeEach
   void setupAll() {
-    member = BaseTestEntity.createMemberNoId();
-    diary = BaseTestEntity.createDiaryNoIdWithMember(member);
+    member = BaseTestObject.createMemberNoId();
+    diary = BaseTestObject.createDiaryNoIdWithMember(member);
     memberRepository.save(member);
     diaryRepository.save(diary);
   }
@@ -47,7 +47,7 @@ public class DiaryReactionRepositoryTest {
     Long expectedSurprised = 3L;
     Long expectedEmpathize = 14L;
     Long expectedCheering = 100L;
-    MemberEntity testMember = BaseTestEntity.createMemberNoId();
+    MemberEntity testMember = BaseTestObject.createMemberNoId();
     memberRepository.save(testMember);
     // LIKE 1개 생성
     diaryReactionRepository.save(
@@ -59,7 +59,7 @@ public class DiaryReactionRepositoryTest {
 
     // SURPRISED 3개 생성
     for (int i = 0; i < expectedSurprised; i++) {
-      testMember = BaseTestEntity.createMemberNoId();
+      testMember = BaseTestObject.createMemberNoId();
       memberRepository.save(testMember);
       diaryReactionRepository.save(
           DiaryReactionEntity.builder()
@@ -71,7 +71,7 @@ public class DiaryReactionRepositoryTest {
 
     // EMPATHIZE 14개 생성
     for (int i = 0; i < expectedEmpathize; i++) {
-      testMember = BaseTestEntity.createMemberNoId();
+      testMember = BaseTestObject.createMemberNoId();
       memberRepository.save(testMember);
       diaryReactionRepository.save(
           DiaryReactionEntity.builder()
@@ -83,7 +83,7 @@ public class DiaryReactionRepositoryTest {
 
     // CHEERING 100개 생성
     for (int i = 0; i < expectedCheering; i++) {
-      testMember = BaseTestEntity.createMemberNoId();
+      testMember = BaseTestObject.createMemberNoId();
       memberRepository.save(testMember);
       diaryReactionRepository.save(
           DiaryReactionEntity.builder()
@@ -199,7 +199,7 @@ public class DiaryReactionRepositoryTest {
   @Test
   @DisplayName("toggleReactionStatus - 다른 멤버가 같은 일기에 같은 타입의 반응을 하면 모두 저장됨")
   void toggleSameReactionTypeDifferentMemberTest() {
-    MemberEntity anotherMember = BaseTestEntity.createMemberNoId();
+    MemberEntity anotherMember = BaseTestObject.createMemberNoId();
     memberRepository.save(anotherMember);
 
     DiaryReactionEntity reaction1 =

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -2,7 +2,7 @@ package com.heartsave.todaktodak_api.diary.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -36,8 +36,8 @@ public class DiaryRepositoryTest {
 
   @BeforeEach
   void setup() {
-    member = BaseTestEntity.createMemberNoId();
-    diary = BaseTestEntity.createDiaryNoIdWithMember(member);
+    member = BaseTestObject.createMemberNoId();
+    diary = BaseTestObject.createDiaryNoIdWithMember(member);
     memberRepository.save(member);
     diaryRepository.save(diary);
   }
@@ -81,8 +81,8 @@ public class DiaryRepositoryTest {
   @DisplayName("멤버 ID 및 시작/끝 날짜에 해당하는 데이터 가져오기")
   void findDiaryByMemberIdAndDates() {
     diaryRepository.delete(diary);
-    DiaryEntity diary1 = BaseTestEntity.createDiaryNoIdWithMember(member);
-    DiaryEntity diary2 = BaseTestEntity.createDiaryNoIdWithMember(member);
+    DiaryEntity diary1 = BaseTestObject.createDiaryNoIdWithMember(member);
+    DiaryEntity diary2 = BaseTestObject.createDiaryNoIdWithMember(member);
     diaryRepository.save(diary1);
     diaryRepository.save(diary2);
     int testYear = diary1.getDiaryCreatedTime().getYear();

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
@@ -2,7 +2,7 @@ package com.heartsave.todaktodak_api.diary.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryContentOnlyProjection;
@@ -35,7 +35,7 @@ class MySharedDiaryRepositoryTest {
 
   @BeforeEach
   void setUp() {
-    member = BaseTestEntity.createMemberNoId();
+    member = BaseTestObject.createMemberNoId();
     tem.persist(member);
 
     publicDiaries = createTestPublicDiaries();
@@ -47,7 +47,7 @@ class MySharedDiaryRepositoryTest {
     List<PublicDiaryEntity> publicDiaries = new ArrayList<>();
     for (int i = 0; i < TEST_PUBLIC_DIARY_SIZE; i++) {
       DiaryEntity diary =
-          BaseTestEntity.createDiaryNoIdWithMemberAndCreatedDateTime(
+          BaseTestObject.createDiaryNoIdWithMemberAndCreatedDateTime(
               member, LocalDateTime.now().minusDays(TEST_PUBLIC_DIARY_SIZE - (i + 1)));
       PublicDiaryEntity publicDiary =
           PublicDiaryEntity.builder()
@@ -76,7 +76,7 @@ class MySharedDiaryRepositoryTest {
   @Test
   @DisplayName("공개 일기가 없는 경우 빈 Optional을 반환한다")
   void shouldReturnEmptyOptionalWhenNoPublicDiaries() {
-    MemberEntity newMember = BaseTestEntity.createMemberNoId();
+    MemberEntity newMember = BaseTestObject.createMemberNoId();
     tem.persist(newMember);
     tem.flush();
     tem.clear();

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/PublicDiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/PublicDiaryRepositoryTest.java
@@ -3,7 +3,7 @@ package com.heartsave.todaktodak_api.diary.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
@@ -44,8 +44,8 @@ public class PublicDiaryRepositoryTest {
 
   @BeforeEach
   void setup() {
-    member = BaseTestEntity.createMemberNoId();
-    diary = BaseTestEntity.createDiaryNoIdWithMember(member);
+    member = BaseTestObject.createMemberNoId();
+    diary = BaseTestObject.createDiaryNoIdWithMember(member);
 
     memberRepository.save(member);
     diaryRepository.save(diary);
@@ -57,8 +57,8 @@ public class PublicDiaryRepositoryTest {
             .publicContent(PUBLIC_CONTENT)
             .build();
 
-    member1 = BaseTestEntity.createMemberNoId();
-    diary1 = BaseTestEntity.createDiaryNoIdWithMember(member1);
+    member1 = BaseTestObject.createMemberNoId();
+    diary1 = BaseTestObject.createDiaryNoIdWithMember(member1);
     memberRepository.save(member1);
     diary1 = diaryRepository.save(diary1);
     publicDiary1 =
@@ -69,8 +69,8 @@ public class PublicDiaryRepositoryTest {
             .build();
     publicDiaryRepository.save(publicDiary1);
 
-    member2 = BaseTestEntity.createMemberNoId();
-    diary2 = BaseTestEntity.createDiaryNoIdWithMember(member2);
+    member2 = BaseTestObject.createMemberNoId();
+    diary2 = BaseTestObject.createDiaryNoIdWithMember(member2);
     memberRepository.save(member2);
     diary2 = diaryRepository.save(diary2);
     publicDiary2 =

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.heartsave.todaktodak_api.ai.client.dto.response.AiDiaryContentResponse;
 import com.heartsave.todaktodak_api.ai.client.service.AiClientService;
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
@@ -66,8 +66,8 @@ public class DiaryServiceTest {
 
   @BeforeEach
   void allSetup() {
-    member = BaseTestEntity.createMember();
-    diary = BaseTestEntity.createDiaryWithMember(member);
+    member = BaseTestObject.createMember();
+    diary = BaseTestObject.createDiaryWithMember(member);
 
     principal = mock(TodakUser.class);
     when(principal.getId()).thenReturn(member.getId());

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
@@ -57,8 +57,8 @@ class PublicDiaryServiceTest {
 
   @BeforeEach
   void setup() {
-    member = BaseTestEntity.createMember();
-    diary = BaseTestEntity.createDiaryWithMember(member);
+    member = BaseTestObject.createMember();
+    diary = BaseTestObject.createDiaryWithMember(member);
 
     principal = mock(TodakUser.class);
     when(principal.getId()).thenReturn(member.getId());

--- a/src/test/java/com/heartsave/todaktodak_api/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/member/repository/MemberRepositoryTest.java
@@ -2,7 +2,7 @@ package com.heartsave.todaktodak_api.member.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -65,7 +65,7 @@ class MemberRepositoryTest {
   @DisplayName("중복 이메일 확인")
   void getDupliactedEmailTest() {
     // Given
-    MemberEntity member = memberRepository.save(BaseTestEntity.createMemberNoId());
+    MemberEntity member = memberRepository.save(BaseTestObject.createMemberNoId());
 
     // When
     boolean isExisted = memberRepository.existsByEmail(member.getEmail());
@@ -78,7 +78,7 @@ class MemberRepositoryTest {
   @DisplayName("회원 프로필 조회")
   void getMemberProfileProjectionTest() {
     // Given
-    MemberEntity member = memberRepository.save(BaseTestEntity.createMemberNoId());
+    MemberEntity member = memberRepository.save(BaseTestObject.createMemberNoId());
 
     // When
     var memberProfile = memberRepository.findProjectedById(member.getId()).orElse(null);

--- a/src/test/java/com/heartsave/todaktodak_api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/member/service/MemberServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-import com.heartsave.todaktodak_api.common.BaseTestEntity;
+import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
 import com.heartsave.todaktodak_api.member.dto.request.NicknameUpdateRequest;
@@ -37,7 +37,7 @@ final class MemberServiceTest {
 
   @BeforeEach
   void setup() {
-    member = BaseTestEntity.createMember();
+    member = BaseTestObject.createMember();
     memberProfileProjection =
         new MemberProfileProjection() {
           @Override


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- AI 서버가 BGM 생성 완료 요청을 보내면, Spring은 BGM URL을 DB에 저장합니다.
-  ```AiRepository``` 의 구조를 바꿨습니다. 
1. ```AiRepository``` 라는 class의 필드로 ```AiJpaRepository``` 를 두어  간단한 ```Facade``` 패턴을 적용했습니다.
2. 이로 인해, ```Service``` 계층에서는 jpa의 모든 메서드가 아닌, 필요한 Repository 메서들만 사용할 수 있습니다.
3. 또한, 반환값이 ```Optional```인 경우 혹은 ```예외를 던지는 코드```가 필요하다면, ```Repository```클래스의 메서드 내부적으로 처리가 가능하기에, ```Service``` 계층의 코드가 깔끔해질 것으로 기대됩니다.

## 리뷰 받고 싶은 내용
- BGM 저장 로직 및 Repository 구조 중심으로 봐주시면 감사하겠습니다.

## 테스트 및 결과
- 로컬 테스트 확인 완료
- ```BaseTestEntity``` -> ```BaseTestObject```로 이름을 변경하였습니다. ```BaseTestObject```가 문자열 상수도 관리하기에, Entity 라는 이름보다 좀 더 추상적인 Object를 사용했습니다. 

## 관련 스크린샷 및 참고자료 (Optional)

### 참고자료
퍼사드(facade) 패턴 : https://refactoring.guru/ko/design-patterns/facade/java/example#example-0
