### PR TITLE
Feature/todak 218/diary infinite scroll response change

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/PublicDiary.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/PublicDiary.java
@@ -37,7 +37,7 @@ public class PublicDiary {
   private final String bgmUrl;
 
   @Schema(description = "일기 작성 날짜", example = "2024-10-26", type = "string", format = "date")
-  private final LocalDate date;
+  private final LocalDate createdDate;
 
   @Schema(description = "일기에 대한 반응 수 정보")
   private final DiaryReactionCountProjection reactionCount;
@@ -63,7 +63,7 @@ public class PublicDiary {
     this.publicContent = content.getPublicContent();
     this.webtoonUrls = content.getWebtoonImageUrls();
     this.bgmUrl = content.getBgmUrl();
-    this.date = content.getDate();
+    this.createdDate = content.getDate();
     this.reactionCount = reactionCount;
     this.myReaction = memberReaction;
   }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/MySharedDiaryPaginationResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/MySharedDiaryPaginationResponse.java
@@ -7,19 +7,25 @@ import java.util.List;
 @Schema(description = "나의 공개된 일기 목록 조회 응답")
 public record MySharedDiaryPaginationResponse(
     @Schema(description = "조회된 공개 일기 목록") List<MySharedDiaryPreviewProjection> sharedDiaries,
-    @Schema(description = "다음 페이지 조회를 위한 마지막 일기 ID", example = "2") Long after) {
+    @Schema(description = "다음 페이지 조회를 위한 마지막 일기 ID", example = "2") Long after,
+    @Schema(description = "조회할 수 있는 다음 페이지 존재 여부 (true: 더 이상 조회 불가)", example = "false")
+        Boolean isEnd) {
 
   public MySharedDiaryPaginationResponse(
-      List<MySharedDiaryPreviewProjection> sharedDiaries, Long after) {
+      List<MySharedDiaryPreviewProjection> sharedDiaries, Long after, Boolean isEnd) {
     this.sharedDiaries = sharedDiaries;
     this.after = after;
+    this.isEnd = isEnd;
   }
 
   public static MySharedDiaryPaginationResponse of(List<MySharedDiaryPreviewProjection> previews) {
     Long minId;
-    if (previews.isEmpty()) minId = 1L;
-    else minId = previews.getLast().getPublicDiaryId();
+    Boolean isEnd = false;
+    if (previews.isEmpty()) {
+      minId = 1L;
+      isEnd = true;
+    } else minId = previews.getLast().getPublicDiaryId();
 
-    return new MySharedDiaryPaginationResponse(previews, minId);
+    return new MySharedDiaryPaginationResponse(previews, minId, isEnd);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/MySharedDiaryPaginationResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/MySharedDiaryPaginationResponse.java
@@ -19,12 +19,11 @@ public record MySharedDiaryPaginationResponse(
   }
 
   public static MySharedDiaryPaginationResponse of(List<MySharedDiaryPreviewProjection> previews) {
-    Long minId;
+    Long minId = 1L;
     Boolean isEnd = false;
-    if (previews.isEmpty()) {
-      minId = 1L;
-      isEnd = true;
-    } else minId = previews.getLast().getPublicDiaryId();
+
+    if (previews.isEmpty()) isEnd = true;
+    else minId = previews.getLast().getPublicDiaryId();
 
     return new MySharedDiaryPaginationResponse(previews, minId, isEnd);
   }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/PublicDiaryPaginationResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/PublicDiaryPaginationResponse.java
@@ -16,14 +16,20 @@ public class PublicDiaryPaginationResponse {
   @Schema(description = "다음 페이지 조회를 위한 마지막 일기 ID", example = "97")
   private Long after;
 
+  @Schema(description = "조회할 수 있는 다음 페이지 존재 여부 (true: 더 이상 조회 불가)", example = "false")
+  private Boolean isEnd;
+
   public PublicDiaryPaginationResponse() {
     this.diaries = new ArrayList<>();
     this.after = 1L;
+    this.isEnd = true;
   }
 
   public void addPublicDiary(PublicDiary publicDiary) {
     diaries.add(publicDiary);
-    if (after == 1L) after = publicDiary.getPublicDiaryId();
-    else after = Math.min(publicDiary.getPublicDiaryId(), after);
+    if (after == 1L) {
+      after = publicDiary.getPublicDiaryId();
+      isEnd = false;
+    } else after = Math.min(publicDiary.getPublicDiaryId(), after);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
@@ -46,12 +46,7 @@ public class MySharedDiaryService {
   }
 
   private Long getFirstPreviewId(Long memberId) {
-    return mySharedDiaryRepository
-        .findLatestId(memberId)
-        .map(id -> id + 1L)
-        .orElseThrow(
-            () ->
-                new PublicDiaryNotFoundException(PublicDiaryErrorSpec.PUBLIC_DIARY_NOT_FOUND, 0L));
+    return mySharedDiaryRepository.findLatestId(memberId).map(id -> id + 1L).orElse(1L);
   }
 
   private void replaceWithPreSignedUrls(List<MySharedDiaryPreviewProjection> previews) {

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
@@ -1,7 +1,6 @@
 package com.heartsave.todaktodak_api.diary.service;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
-import com.heartsave.todaktodak_api.common.exception.errorspec.PublicDiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
@@ -14,7 +13,6 @@ import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import com.heartsave.todaktodak_api.diary.entity.projection.PublicDiaryContentOnlyProjection;
 import com.heartsave.todaktodak_api.diary.exception.DiaryNotFoundException;
-import com.heartsave.todaktodak_api.diary.exception.PublicDiaryNotFoundException;
 import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.diary.repository.PublicDiaryRepository;
@@ -46,18 +44,13 @@ public class PublicDiaryService {
 
   private List<PublicDiaryContentOnlyProjection> fetchDiaryContents(Long publicDiaryId) {
     log.info("공개 일기 content 정보를 조회합니다.");
-    if (publicDiaryId == 0) publicDiaryId = getMaxId(); // 공개 일기 조회 API 첫 호출
+    if (publicDiaryId == 0) publicDiaryId = getFirstPaginationId(); // 공개 일기 조회 API 첫 호출
     return publicDiaryRepository.findNextContentOnlyById(
         publicDiaryId, PageRequest.of(0, 5)); // 현재 ID 제외, 다음 ID 포함 5개 조회
   }
 
-  private Long getMaxId() {
-    return publicDiaryRepository
-        .findLatestId()
-        .map(id -> id + 1)
-        .orElseThrow(
-            () ->
-                new PublicDiaryNotFoundException(PublicDiaryErrorSpec.PUBLIC_DIARY_NOT_FOUND, 0L));
+  private Long getFirstPaginationId() {
+    return publicDiaryRepository.findLatestId().map(id -> id + 1).orElse(1L);
   }
 
   private void replaceWithPreSignedUrls(List<PublicDiaryContentOnlyProjection> diaryContents) {

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
@@ -213,6 +213,7 @@ class PublicDiaryServiceTest {
 
     // then
     assertThat(response).as("응답이 null이 아니어야 합니다").isNotNull();
+    assertThat(response.getIsEnd()).as("응답 데이터가 있기 때문에 isEnd 조건은 false 이어야 합니다.").isFalse();
 
     List<PublicDiary> publicDairies = response.getDiaries();
     assertThat(publicDairies).as("조회된 일기 목록이 비어있지 않아야 합니다").isNotNull();
@@ -277,5 +278,6 @@ class PublicDiaryServiceTest {
         publicDiaryService.getPublicDiaryPagination(principal, publicDiaryId);
 
     assertThat(response.getDiaries().size()).as("조회 결과가 없는 경우 빈 목록이 반환되어야 합니다").isEqualTo(0);
+    assertThat(response.getIsEnd()).as("조회 결과가 없는 경우 isEnd 조건이 True가 돼야 합니다.").isTrue();
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
@@ -250,21 +250,23 @@ class PublicDiaryServiceTest {
   @Test
   @DisplayName("getPublicDiaryPaginationResponse - 최신 일기 조회 (publicDiaryId = 0)")
   void getPublicDiaryPaginationResponse_LatestDiary() {
-    // given
-    Long latestId = 100L;
-    when(mockPublicDiaryRepository.findLatestId()).thenReturn(Optional.of(latestId));
-    when(mockPublicDiaryRepository.findNextContentOnlyById(
-            eq(latestId + 1), any(PageRequest.class)))
-        .thenReturn(List.of());
+    PublicDiaryContentOnlyProjection content = mock(PublicDiaryContentOnlyProjection.class);
+    DiaryReactionCountProjection reactionCount = mock(DiaryReactionCountProjection.class);
+    List<DiaryReactionType> reactionType = mock(List.class);
+    when(mockPublicDiaryRepository.findLatestId()).thenReturn(Optional.empty());
+    when(mockPublicDiaryRepository.findNextContentOnlyById(eq(1L), any(PageRequest.class)))
+        .thenReturn(List.of(content));
+    when(mockDiaryReactionRepository.countEachByDiaryId(anyLong())).thenReturn(reactionCount);
+    when(mockDiaryReactionRepository.findMemberReaction(anyLong(), anyLong()))
+        .thenReturn(reactionType);
 
-    // when
     PublicDiaryPaginationResponse response =
         publicDiaryService.getPublicDiaryPagination(principal, 0L);
 
-    // then
+    assertThat(response.getDiaries().size()).as("조회된 일기가 1개 있어야 한다").isEqualTo(1L);
+    assertThat(response.getIsEnd()).as("다음 페이지 조회가 가능하므로 isEnd는 false여야 한다").isFalse();
     verify(mockPublicDiaryRepository).findLatestId();
-    verify(mockPublicDiaryRepository)
-        .findNextContentOnlyById(eq(latestId + 1), any(PageRequest.class));
+    verify(mockPublicDiaryRepository).findNextContentOnlyById(eq(1L), any(PageRequest.class));
   }
 
   @Test


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 무한 스크롤 API 응답 데이터에 ```isEnd``` 조건을 추가하였습니다.
- 나의 게시물/공개 일기(피드) 무한 스크롤 API에 ```isEnd```를 모두 적용하였습니다.
- 두 API의 ```after``` 데이터에 1L 을 넣고 API 요청을 보내면, 빈 객체가 응답되며, ```isEnd``` 조건은 ```True```로 설정됩니다.
- 무한 스크롤 API 에서 DB에 데이터가 아예 없으면 예외를 던지는 것이 아닌, 빈 객체를 응답합니다.

## 리뷰 받고 싶은 내용

- 두 API의 응답 객체(```MySharedDiaryResponse``` 와 ```PublicDiaryPaginationResponse```)의 생성자 조건에 오류가 없는지를 중심으로 봐주시면 감사하겠습니다.

## 테스트 및 결과
- 테스트로 확인한 부분 추가

## 관련 스크린샷 및 참고자료 (Optional)

close #90 