### PR TITLE
!HOTFIX: AI 일기 컨텐츠 비동기 테스트 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # todaktodak-api
-토닥토닥 서비스의 API
+토닥토닥 서비스의 API 

--- a/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
@@ -8,7 +8,6 @@ import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -42,7 +41,7 @@ class AiClientServiceTest {
           public MockResponse dispatch(RecordedRequest request) {
             switch (request.getPath()) {
               case WEBTOON_URI, BGM_URI:
-                return new MockResponse().setHeadersDelay(300, TimeUnit.MILLISECONDS);
+                return new MockResponse();
               case COMMENT_URI:
                 return new MockResponse().setResponseCode(200).setBody(AI_COMMENT);
               default:
@@ -73,7 +72,6 @@ class AiClientServiceTest {
 
     AiDiaryContentResponse aiResponse = aiClientService.callDiaryContent(diary);
     log.info("aiComment 결과 = {}", aiResponse.getAiComment());
-    Thread.sleep(300);
     assertThat(aiResponse.getAiComment()).as("AI 코멘트 비동기 요청 응답이 올바르지 않습니다.").isEqualTo(AI_COMMENT);
 
     for (int i = 0; i < mockWebServer.getRequestCount(); i++) {


### PR DESCRIPTION
- mockServer 및 sleep에 관한 ms 제한을 해제하여 즉시 응답하도록 변경


<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

### 기존
- ```AiClientServcie``` 테스트 시, mockWebServer 에서 비동기임을 가정하여 지연 응답(300ms)을 설정하였습니다.
- 지연 응답으로 인해 테스트 메서드가 너무 빨리 닫혀 예외가 발생하여, 지연 응답을 기다리기 위해 Thread sleep을 사용하였습니다.

### 변경
- Github Action의 빌드 과정 중, ```IOException```이 발생하여 지연 응답 및 Thread sleep을 제거하였습니다.

## 리뷰 받고 싶은 내용


## 테스트 및 결과
- 테스트로 확인한 부분 추가

## 관련 스크린샷 및 참고자료 (Optional)
