### PR TITLE
Feature/todak 227/diary s3 url save

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
@@ -16,15 +16,15 @@ public class ClientWebtoonRequest {
   private final String content;
   private final String characterInfo;
   private final Integer seedNum;
-
-  // Todo : characterStyle enum 추가
+  private final String characterStyle;
 
   private ClientWebtoonRequest(DiaryEntity diary, MemberEntity member) {
     this.memberId = member.getId();
     this.date = diary.getDiaryCreatedTime().toLocalDate();
     this.content = diary.getContent();
-    this.characterInfo = (String) member.getCharacterInfo();
+    this.characterInfo = member.getCharacterInfo();
     this.seedNum = member.getCharacterSeed();
+    this.characterStyle = member.getCharacterStyle();
   }
 
   public static ClientWebtoonRequest of(DiaryEntity diary, MemberEntity member) {

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/WebhookCharacterCompletionRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/WebhookCharacterCompletionRequest.java
@@ -3,7 +3,6 @@ package com.heartsave.todaktodak_api.ai.webhook.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
@@ -15,7 +14,5 @@ public record WebhookCharacterCompletionRequest(
         String characterInfo,
     @NotBlank @Schema(example = "romance", description = "캐릭터 화풍") String characterStyle,
     @NotNull @Positive @Schema(example = "13564", description = "캐릭터 이미지 시드") Integer seedNum,
-    @NotBlank
-        @Pattern(regexp = "^.+/.+$") // 슬래시 앞뒤에 문자 존재
-        @Schema(example = "character/memberId", description = "캐릭터 이미지 경로")
+    @NotBlank @Schema(example = "character/memberId", description = "캐릭터 이미지 경로")
         String characterUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepository.java
@@ -12,13 +12,12 @@ public class AiRepository {
 
   private final AiJpaRepository jpaRepository;
 
-  public int updateWebtoonUrl(WebhookWebtoonCompletionRequest request) {
-    return jpaRepository.updateWebtoonUrl(
-        request.memberId(), request.createdDate(), request.webtoonFolderUrl());
+  public int updateWebtoonUrl(WebhookWebtoonCompletionRequest request, String url) {
+    return jpaRepository.updateWebtoonUrl(request.memberId(), request.createdDate(), url);
   }
 
-  public int updateBgmUrl(WebhookBgmCompletionRequest request) {
-    return jpaRepository.updateBgmUrl(request.memberId(), request.createdDate(), request.bgmUrl());
+  public int updateBgmUrl(WebhookBgmCompletionRequest request,String url) {
+    return jpaRepository.updateBgmUrl(request.memberId(), request.createdDate(), url);
   }
 
   public Boolean isContentCompleted(Long memberId, LocalDate createdDate) {

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
@@ -3,6 +3,7 @@ package com.heartsave.todaktodak_api.ai.webhook.service;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookBgmCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import java.time.LocalDate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,12 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class AiDiaryService {
 
   AiRepository aiRepository;
+  S3FileStorageService s3FileStorageService;
 
   public void saveWebtoon(WebhookWebtoonCompletionRequest request) {
     Long memberId = request.memberId();
     LocalDate createdDate = request.createdDate();
     log.info("webtoon url 업데이트를 시작합니다.");
-    int result = aiRepository.updateWebtoonUrl(request);
+    String keyUrl = s3FileStorageService.parseKeyFrom(request.webtoonFolderUrl());
+    int result = aiRepository.updateWebtoonUrl(request, keyUrl);
     if (result == 0) {
       log.warn("Webtoon Url을 업데이트 할 일기가 없습니다. memberId={}, diaryDate={}", memberId, createdDate);
       return;
@@ -33,9 +36,9 @@ public class AiDiaryService {
   public void saveBgm(WebhookBgmCompletionRequest request) {
     Long memberId = request.memberId();
     LocalDate createdDate = request.createdDate();
-
+    String keyUrl = s3FileStorageService.parseKeyFrom(request.bgmUrl());
     log.info("Bgm url 업데이트를 시작합니다. memberId={}", memberId);
-    int result = aiRepository.updateBgmUrl(request);
+    int result = aiRepository.updateBgmUrl(request, keyUrl);
     if (result == 0) {
       log.warn("bgm Url을 업데이트 할 일기가 없습니다. memberId={}, diaryDate={}", memberId, createdDate);
       return;

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
@@ -2,6 +2,7 @@ package com.heartsave.todaktodak_api.ai.webhook.service;
 
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookCharacterCompletionRequest;
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AiWebhookCharacterService {
   private final MemberRepository memberRepository;
+  private final S3FileStorageService s3Service;
 
   public void saveCharacterAndNotify(WebhookCharacterCompletionRequest dto) {
     saveCharacter(dto);
@@ -26,6 +28,8 @@ public class AiWebhookCharacterService {
         memberRepository
             .findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException(MemberErrorSpec.NOT_FOUND, memberId));
-    retrievedMember.updateCharacterInfo(dto.characterInfo(), dto.characterStyle(), dto.seedNum());
+    String url = s3Service.parseKeyFrom(dto.characterUrl());
+    retrievedMember.updateCharacterInfo(
+        dto.characterInfo(), dto.characterStyle(), dto.seedNum(), url);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/S3ErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/S3ErrorSpec.java
@@ -1,0 +1,18 @@
+package com.heartsave.todaktodak_api.common.exception.errorspec;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum S3ErrorSpec implements ErrorSpec {
+  INVALID_S3_URL(
+      HttpStatus.BAD_REQUEST, "S3-001", "유효하지 않은 S3 URL 입니다.", "AI 서버가 요청한 URL이 유효하지 않습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String clientMessage;
+  private final String debugMessage;
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageService.java
@@ -27,17 +27,19 @@ public class S3FileStorageService {
 
   // TODO: 존재하지 않는 이미지 key에 대한 예외 처리 필요
   public List<String> preSignedWebtoonUrlFrom(List<String> s3FolderUrl) {
-    List<String> preSigendUrls = new ArrayList<>();
-    String folderUrl = s3FolderUrl.getFirst();
+    if (s3FolderUrl.isEmpty()) return List.of();
 
+    List<String> s3ImageUrls = new ArrayList<>();
+    String folderUrl = s3FolderUrl.getFirst();
     for (int order = 1; order <= s3FolderUrl.size(); order++) {
-      preSigendUrls.add(folderUrl + "/" + order + ".webp");
+      s3ImageUrls.add(folderUrl + "/" + order + ".webp");
     }
-    return preSigendUrls.stream().map(this::preSign).toList();
+
+    return s3ImageUrls.stream().map(this::preSign).toList();
   }
 
   public String preSignedFirstWebtoonUrlFrom(String key) {
-    return key == null ? preSign(s3Properties.defaultKey().webtoon()) : preSign(key);
+    return key == null ? preSign(s3Properties.defaultKey().webtoon()) : preSign(key + "/1.webp");
   }
 
   public String preSignedCharacterImageUrlFrom(String key) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/expcetion/InvalidS3UrlException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/expcetion/InvalidS3UrlException.java
@@ -1,0 +1,11 @@
+package com.heartsave.todaktodak_api.common.storage.s3.expcetion;
+
+import com.heartsave.todaktodak_api.common.exception.ErrorFieldBuilder;
+import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
+
+public class InvalidS3UrlException extends S3Exception {
+
+  public InvalidS3UrlException(ErrorSpec errorSpec, String url) {
+    super(errorSpec, ErrorFieldBuilder.builder().add("s3Url", url).build());
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/expcetion/S3Exception.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/expcetion/S3Exception.java
@@ -1,0 +1,11 @@
+package com.heartsave.todaktodak_api.common.storage.s3.expcetion;
+
+import com.heartsave.todaktodak_api.common.exception.BaseException;
+import com.heartsave.todaktodak_api.common.exception.ErrorField;
+import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
+
+public abstract class S3Exception extends BaseException {
+  protected S3Exception(ErrorSpec errorSpec, ErrorField errorField) {
+    super(errorSpec, errorField);
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/DiaryWriteRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/DiaryWriteRequest.java
@@ -6,6 +6,7 @@ import static com.heartsave.todaktodak_api.diary.constant.DiaryContentConstraint
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
@@ -24,6 +25,7 @@ public class DiaryWriteRequest {
       format = "date-time",
       example = "2024-10-26T15:30:00")
   @PastOrPresent(message = "Diary Writing Date is Future")
+  @NotNull
   @JsonProperty("date")
   private LocalDateTime dateTime;
 
@@ -40,5 +42,6 @@ public class DiaryWriteRequest {
       min = DIARY_CONTENT_MIN_SIZE,
       max = DIARY_CONTENT_MAX_SIZE,
       message = "Diary Content Length Out Of Range")
+  @NotBlank
   private String content;
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -7,7 +7,7 @@ import com.heartsave.todaktodak_api.ai.client.service.AiClientService;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryResponse;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
@@ -2,7 +2,7 @@ package com.heartsave.todaktodak_api.diary.service;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.PublicDiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.dto.response.MySharedDiaryPaginationResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.MySharedDiaryResponse;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
@@ -2,7 +2,7 @@ package com.heartsave.todaktodak_api.diary.service;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.dto.PublicDiary;
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;

--- a/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
@@ -60,9 +60,10 @@ public class MemberEntity extends BaseEntity {
   }
 
   public void updateCharacterInfo(
-      String characterInfo, String characterStyle, Integer characterSeed) {
+      String characterInfo, String characterStyle, Integer characterSeed, String characterUrl) {
     this.characterInfo = characterInfo;
     this.characterStyle = characterStyle;
     this.characterSeed = characterSeed;
+    this.characterImageUrl = characterUrl;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
@@ -9,7 +9,7 @@ import com.heartsave.todaktodak_api.common.security.constant.JwtConstant;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.security.util.CookieUtils;
 import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.member.domain.TodakRole;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterRegisterResponse;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterTemporaryImageResponse;

--- a/src/main/java/com/heartsave/todaktodak_api/member/service/MemberService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/service/MemberService.java
@@ -5,7 +5,7 @@ import static com.heartsave.todaktodak_api.common.security.util.CookieUtils.*;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.member.dto.request.NicknameUpdateRequest;
 import com.heartsave.todaktodak_api.member.dto.response.MemberProfileResponse;
 import com.heartsave.todaktodak_api.member.dto.response.NicknameUpdateResponse;

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
@@ -256,11 +256,7 @@ class AiWebhookControllerTest {
           Arguments.of(1L, "", "romance", 123, "folder/image", "characterInfo must not be blank"),
 
           // 음수 시드값
-          Arguments.of(1L, "{ \"hair\": \"long\" }", "romance", -1, "folder/image"),
-
-          // 유효하지 않은 character url
-          Arguments.of(1L, "{ \"hair\": \"long\" }", "romance", 123, "/"),
-          Arguments.of(1L, "{ \"hair\": \"long\" }", "romance", 123, "invalid"));
+          Arguments.of(1L, "{ \"hair\": \"long\" }", "romance", -1, "folder/image"));
     }
 
     @Test

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepositoryTest.java
@@ -60,7 +60,7 @@ class AiRepositoryTest {
           new WebhookWebtoonCompletionRequest(
               member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newUrl);
 
-      aiRepository.updateWebtoonUrl(request);
+      aiRepository.updateWebtoonUrl(request, request.webtoonFolderUrl());
 
       DiaryEntity updatedDiary = tem.find(DiaryEntity.class, diary.getId());
       assertThat(updatedDiary.getWebtoonImageUrl()).isEqualTo(newUrl);
@@ -74,7 +74,7 @@ class AiRepositoryTest {
       WebhookWebtoonCompletionRequest request =
           new WebhookWebtoonCompletionRequest(member.getId(), nonExistentDate, newUrl);
 
-      aiRepository.updateWebtoonUrl(request);
+      aiRepository.updateWebtoonUrl(request, request.webtoonFolderUrl());
 
       DiaryEntity unchangedDiary = tem.find(DiaryEntity.class, diary.getId());
       assertThat(unchangedDiary.getWebtoonImageUrl()).isEqualTo("");
@@ -93,7 +93,7 @@ class AiRepositoryTest {
           new WebhookBgmCompletionRequest(
               member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newBgmUrl);
 
-      aiRepository.updateBgmUrl(request);
+      aiRepository.updateBgmUrl(request, request.bgmUrl());
 
       DiaryEntity updatedDiary = tem.find(DiaryEntity.class, diary.getId());
       assertThat(updatedDiary.getBgmUrl()).isEqualTo(newBgmUrl);
@@ -108,7 +108,7 @@ class AiRepositoryTest {
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(member.getId(), nonExistentDate, newBgmUrl);
 
-      aiRepository.updateBgmUrl(request);
+      aiRepository.updateBgmUrl(request, request.bgmUrl());
 
       DiaryEntity unchangedDiary = tem.find(DiaryEntity.class, diary.getId());
       assertThat(unchangedDiary.getBgmUrl()).isEqualTo("");
@@ -138,7 +138,7 @@ class AiRepositoryTest {
           new WebhookBgmCompletionRequest(
               member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newBgmUrl);
 
-      aiRepository.updateBgmUrl(request);
+      aiRepository.updateBgmUrl(request, request.bgmUrl());
 
       DiaryEntity targetDiary = tem.find(DiaryEntity.class, diary.getId());
       DiaryEntity otherDiary = tem.find(DiaryEntity.class, diary2.getId());

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookBgmCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,17 +23,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class AiDiaryServiceTest {
 
   @Mock private AiRepository aiRepository;
+  @Mock private S3FileStorageService s3FileStorageService;
   @InjectMocks private AiDiaryService aiDiaryService;
 
   private WebhookWebtoonCompletionRequest webtoonRequest;
   private WebhookBgmCompletionRequest bgmRequest;
   private final Long memberId = 1L;
   private final LocalDate createdDate = LocalDate.now();
+  private final String parseKeyUrl = "parse-key-url";
 
   @BeforeEach
   void setUp() {
     webtoonRequest = new WebhookWebtoonCompletionRequest(memberId, createdDate, TEST_WEBTOON_URL);
     bgmRequest = new WebhookBgmCompletionRequest(memberId, createdDate, TEST_BGM_URL);
+    when(s3FileStorageService.parseKeyFrom(anyString())).thenReturn(parseKeyUrl);
   }
 
   @Nested
@@ -42,24 +46,24 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("웹툰 URL 업데이트 성공 및 AI 컨텐츠 생성이 미완료된 경우")
     void saveWebtoon_UpdateSuccessAndAiContentCompleted() {
-      when(aiRepository.updateWebtoonUrl(webtoonRequest)).thenReturn(1);
+      when(aiRepository.updateWebtoonUrl(webtoonRequest, parseKeyUrl)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(false);
 
       aiDiaryService.saveWebtoon(webtoonRequest);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest);
+      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest, parseKeyUrl);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
     }
 
     @Test
     @DisplayName("웹툰 URL 업데이트 성공 및 AI 컨텐츠 생성이 완료된 경우")
     void saveWebtoon_UpdateSuccessAndCustomBgmUrl() {
-      when(aiRepository.updateWebtoonUrl(webtoonRequest)).thenReturn(1);
+      when(aiRepository.updateWebtoonUrl(webtoonRequest, parseKeyUrl)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(true);
 
       aiDiaryService.saveWebtoon(webtoonRequest);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest);
+      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest, parseKeyUrl);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
       // Todo: SSE 알림 관련 검증 추가 필요
     }
@@ -67,11 +71,11 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("업데이트할 일기가 없는 경우")
     void saveWebtoon_NoDataToUpdate() {
-      when(aiRepository.updateWebtoonUrl(webtoonRequest)).thenReturn(0);
+      when(aiRepository.updateWebtoonUrl(webtoonRequest, parseKeyUrl)).thenReturn(0);
 
       aiDiaryService.saveWebtoon(webtoonRequest);
 
-      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest);
+      verify(aiRepository, times(1)).updateWebtoonUrl(webtoonRequest, parseKeyUrl);
       verify(aiRepository, never()).isContentCompleted(any(), any());
     }
   }
@@ -83,24 +87,24 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("BGM URL 업데이트 성공 및 AI 컨텐츠 생성이 미완료된 경우")
     void saveBgm_UpdateSuccessAndAiContentNotCompleted() {
-      when(aiRepository.updateBgmUrl(bgmRequest)).thenReturn(1);
+      when(aiRepository.updateBgmUrl(bgmRequest, parseKeyUrl)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(false);
 
       aiDiaryService.saveBgm(bgmRequest);
 
-      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest);
+      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest, parseKeyUrl);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
     }
 
     @Test
     @DisplayName("BGM URL 업데이트 성공 및 AI 컨텐츠 생성이 완료된 경우")
     void saveBgm_UpdateSuccessAndAiContentCompleted() {
-      when(aiRepository.updateBgmUrl(bgmRequest)).thenReturn(1);
+      when(aiRepository.updateBgmUrl(bgmRequest, parseKeyUrl)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(true);
 
       aiDiaryService.saveBgm(bgmRequest);
 
-      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest);
+      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest, parseKeyUrl);
       verify(aiRepository, times(1)).isContentCompleted(memberId, createdDate);
       // Todo: SSE 알림 관련 검증 추가 필요
     }
@@ -108,11 +112,11 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("업데이트할 일기가 없는 경우")
     void saveBgm_NoDataToUpdate() {
-      when(aiRepository.updateBgmUrl(bgmRequest)).thenReturn(0);
+      when(aiRepository.updateBgmUrl(bgmRequest, parseKeyUrl)).thenReturn(0);
 
       aiDiaryService.saveBgm(bgmRequest);
 
-      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest);
+      verify(aiRepository, times(1)).updateBgmUrl(bgmRequest, parseKeyUrl);
       verify(aiRepository, never()).isContentCompleted(any(), any());
     }
   }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookCharacterCompletionRequest;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 final class AiWebhookCharacterServiceTest {
   @Mock private MemberRepository memberRepository;
+  @Mock private S3FileStorageService s3FileStorageService;
   @InjectMocks private AiWebhookCharacterService characterService;
 
   private MemberEntity member;
@@ -41,6 +43,7 @@ final class AiWebhookCharacterServiceTest {
   void saveCharacterAndNotify() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    when(s3FileStorageService.parseKeyFrom(anyString())).thenReturn("s3-bucket-key");
 
     // when
     characterService.saveCharacterAndNotify(request);

--- a/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import com.heartsave.todaktodak_api.common.config.properties.S3Properties;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.*;

--- a/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.*;
 
 import com.heartsave.todaktodak_api.common.config.properties.S3Properties;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.expcetion.InvalidS3UrlException;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.*;
@@ -27,8 +28,11 @@ final class S3FileStorageServiceTest {
 
   private static final String TEST_BUCKET = "test-bucket";
   private static final Long TEST_DURATION = 3600L;
+
   private static final String TEST_PRE_SIGNED_URL =
       "https://test-bucket.s3.amazonaws.com/presigned-url";
+  private static final String TEST_ORIGINAL_URL =
+      "https://test-bucket.s3.amazonaws.com/original-url";
   private static final String DEFAULT_WEBTOON_KEY = "default/webtoon.jpg";
   private static final String DEFAULT_CHARACTER_KEY = "default/character.jpg";
   private static final String DEFAULT_BGM_KEY = "default/bgm.mp3";
@@ -36,7 +40,6 @@ final class S3FileStorageServiceTest {
   @BeforeEach
   void setUp() {
     s3Service = new S3FileStorageService(s3Presigner, s3Properties);
-    mockBasicProperties();
   }
 
   private void mockBasicProperties() {
@@ -61,6 +64,11 @@ final class S3FileStorageServiceTest {
   @Nested
   @DisplayName("웹툰 이미지 presign 테스트")
   final class WebtoonUrlTests {
+
+    @BeforeEach
+    void setUp() {
+      mockBasicProperties();
+    }
 
     @Test
     @DisplayName("웹툰 전체 이미지 presign 성공")
@@ -94,6 +102,12 @@ final class S3FileStorageServiceTest {
   @Nested
   @DisplayName("캐릭터 이미지 presign 테스트")
   final class CharacterUrlTests {
+
+    @BeforeEach
+    void setUp() {
+      mockBasicProperties();
+    }
+
     @Test
     @DisplayName("캐릭터 이미지 presign 성공")
     void preSignCharacterImageUrlSuccessTest() throws Exception {
@@ -126,6 +140,12 @@ final class S3FileStorageServiceTest {
   @Nested
   @DisplayName("BGM presign 테스트")
   final class BgmUrlTests {
+
+    @BeforeEach
+    void setUp() {
+      mockBasicProperties();
+    }
+
     @Test
     @DisplayName("BGM presign 성공")
     void preSignBgmUrlSuccessTest() throws Exception {
@@ -165,5 +185,93 @@ final class S3FileStorageServiceTest {
     // when + then
     assertThatThrownBy(() -> s3Service.preSignedBgmUrlFrom("non-existent.mp3"))
         .isInstanceOf(NoSuchKeyException.class);
+  }
+
+  @Nested
+  @DisplayName("웹툰 폴더 URL presign 테스트")
+  final class WebtoonFolderUrlTests {
+
+    @BeforeEach
+    void setUp() {
+      mockBasicProperties();
+    }
+
+    @Test
+    @DisplayName("웹툰 폴더 URL에서 순차적으로 이미지 URL 생성 및 presign 성공")
+    void preSignedWebtoonUrlFromFolderTest() throws Exception {
+      // given
+      mockPresign();
+      List<String> folderUrls = List.of("webtoon/chapter1");
+
+      // when
+      List<String> presignedUrls = s3Service.preSignedWebtoonUrlFrom(folderUrls);
+
+      // then
+      assertThat(presignedUrls).hasSize(1).allMatch(url -> url.equals(TEST_PRE_SIGNED_URL));
+    }
+  }
+
+  @Test
+  @DisplayName("빈 폴더 URL 리스트에 대해 빈 리스트 반환")
+  void preSignedWebtoonUrlFromEmptyListTest() {
+    // given
+    List<String> emptyUrls = List.of();
+
+    // when
+    List<String> presignedUrls = s3Service.preSignedWebtoonUrlFrom(emptyUrls);
+
+    // then
+    assertThat(presignedUrls).isEmpty();
+  }
+
+  @Nested
+  @DisplayName("S3 URL 파싱 테스트")
+  final class ParseKeyTests {
+
+    private final String VALID_S3_URL =
+        "https://" + TEST_BUCKET + ".s3.amazonaws.com/path/to/file.jpg";
+    private final String EXPECTED_KEY = "/path/to/file.jpg";
+
+    @Test
+    @DisplayName("유효한 S3 URL에서 키 추출 성공")
+    void parseKeyFromValidUrlTest() {
+      // when
+      given(s3Properties.bucketName()).willReturn(TEST_BUCKET);
+      String key = s3Service.parseKeyFrom(VALID_S3_URL);
+
+      // then
+      assertThat(key).isEqualTo(EXPECTED_KEY);
+    }
+
+    @Test
+    @DisplayName("null URL에 대해 예외 발생")
+    void parseKeyFromNullUrlTest() {
+      assertThatThrownBy(() -> s3Service.parseKeyFrom(null))
+          .isInstanceOf(InvalidS3UrlException.class);
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 URL에 대해 예외 발생")
+    void parseKeyFromMalformedUrlTest() {
+      // given
+      given(s3Properties.bucketName()).willReturn(TEST_BUCKET);
+      String invalidUrl = "not-a-url";
+
+      // when + then
+      assertThatThrownBy(() -> s3Service.parseKeyFrom(invalidUrl))
+          .isInstanceOf(InvalidS3UrlException.class);
+    }
+
+    @Test
+    @DisplayName("버킷 이름이 없는 URL에 대해 예외 발생")
+    void parseKeyFromUrlWithoutBucketTest() {
+      // given
+      given(s3Properties.bucketName()).willReturn(TEST_BUCKET);
+      String urlWithoutBucket = "https://different-bucket.s3.amazonaws.com/file.jpg";
+
+      // when + then
+      assertThatThrownBy(() -> s3Service.parseKeyFrom(urlWithoutBucket))
+          .isInstanceOf(InvalidS3UrlException.class);
+    }
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -17,7 +17,7 @@ import com.heartsave.todaktodak_api.ai.client.service.AiClientService;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.common.TestDiaryObjectFactory;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.dto.response.MySharedDiaryPaginationResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.MySharedDiaryResponse;

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.dto.PublicDiary;
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;

--- a/src/test/java/com/heartsave/todaktodak_api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/member/service/MemberServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 
 import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
-import com.heartsave.todaktodak_api.common.storage.S3FileStorageService;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.member.dto.request.NicknameUpdateRequest;
 import com.heartsave.todaktodak_api.member.dto.response.MemberProfileResponse;
 import com.heartsave.todaktodak_api.member.dto.response.NicknameUpdateResponse;


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- AI 서버가 전달해주는 URL을 S3 Key 형태로 추출하여 DB에 저장합니다.
- webtoon url의 경우, 클라이언트에게 제공할 때 약속된 파일 이름을 지정하여 4개의 이미지 파일에 대한 pre-sigend URL을 적용합니다.
- AI 서버에게 웹툰 요청시, 화풍(CharacetStyle) 데이터를 추가 합니다.

## 리뷰 받고 싶은 내용

- S3 추출 및 적용에 대한 로직 오류가 있다면 코멘트 부탁드립니다!

## 테스트 및 결과
- 로컬 테스트 확인 완료했습니다.

## 관련 스크린샷 및 참고자료 (Optional)
