### PR TITLE
Feature/todak 229/sse initialize

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/config/AiServerWebClientConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/config/AiServerWebClientConfig.java
@@ -1,6 +1,5 @@
 package com.heartsave.todaktodak_api.ai.client.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -11,13 +10,9 @@ import org.springframework.web.reactive.function.client.WebClient.Builder;
 @Configuration
 public class AiServerWebClientConfig {
 
-  @Value("${ai.server.url.domain}")
-  private String AI_SERVER_URL_DOMAIN;
-
   @Bean
   public WebClient aiWebClient(Builder webClientBuilder) {
     return webClientBuilder
-        .baseUrl(AI_SERVER_URL_DOMAIN)
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .build();
   }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/config/AiServerWebClientConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/config/AiServerWebClientConfig.java
@@ -14,6 +14,7 @@ public class AiServerWebClientConfig {
   public WebClient aiWebClient(Builder webClientBuilder) {
     return webClientBuilder
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
         .build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/config/properties/AiServerProperties.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/config/properties/AiServerProperties.java
@@ -1,0 +1,6 @@
+package com.heartsave.todaktodak_api.ai.client.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "ai.server.url")
+public record AiServerProperties(String imageDomain, String textDomain, String bgmDomain) {}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/domain/AiComment.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/domain/AiComment.java
@@ -1,0 +1,4 @@
+package com.heartsave.todaktodak_api.ai.client.domain;
+
+
+public record AiComment(String comment) {}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 public class ClientWebtoonRequest {
-  private final Long memberId;
+  private final String memberId;
 
   @JsonFormat(pattern = "yyyy-MM-dd")
   private final LocalDate date;
@@ -19,7 +19,7 @@ public class ClientWebtoonRequest {
   private final String characterStyle;
 
   private ClientWebtoonRequest(DiaryEntity diary, MemberEntity member) {
-    this.memberId = member.getId();
+    this.memberId = String.valueOf(member.getId());
     this.date = diary.getDiaryCreatedTime().toLocalDate();
     this.content = diary.getContent();
     this.characterInfo = member.getCharacterInfo();

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
@@ -69,6 +69,7 @@ public class AiClientService {
         .post()
         .uri(aiServerProperties.textDomain() + "/comment")
         .bodyValue(request)
+        .accept(MediaType.APPLICATION_JSON)
         .retrieve()
         .bodyToMono(AiComment.class)
         .doOnSuccess(result -> log.info("AI 코멘트 생성 요청을 성공적으로 보냈습니다."))

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
@@ -9,12 +9,15 @@ import com.heartsave.todaktodak_api.ai.exception.AiException;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AiErrorSpec;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import java.io.IOException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -94,9 +97,9 @@ public class AiClientService {
         .subscribe();
   }
 
-  private MultiValueMap<String, HttpEntity<?>> createMultipartBody(
+  private MultiValueMap<String, Object> createMultipartBodys(
       MultipartFile image, ClientCharacterRequest request) {
-    MultiValueMap<String, HttpEntity<?>> multipartBody = new LinkedMultiValueMap<>();
+    MultiValueMap<String, Object> multipartBody = new LinkedMultiValueMap<>();
 
     // 요청 json
     multipartBody.add("memberId", new HttpEntity<>(request.memberId()));
@@ -116,5 +119,35 @@ public class AiClientService {
       throw new AiException(AiErrorSpec.IMAGE_PROCESS_FAIL, image.getOriginalFilename());
     }
     return multipartBody;
+  }
+
+  private MultiValueMap<String, HttpEntity<?>> createMultipartBody(
+      MultipartFile image, ClientCharacterRequest request) {
+    MultipartBodyBuilder builder = new MultipartBodyBuilder();
+
+    // 요청 json
+    builder.part("memberId", request.memberId());
+    builder.part("characterStyle", request.characterStyle());
+
+    // 이미지
+    try {
+      ByteArrayResource imageResource =
+          new ByteArrayResource(image.getBytes()) {
+            @Override
+            public String getFilename() {
+              return image.getOriginalFilename();
+            }
+          };
+
+      builder
+          .part("userImage", imageResource)
+          .filename(Objects.requireNonNull(image.getOriginalFilename()))
+          .contentType(MediaType.parseMediaType(Objects.requireNonNull(image.getContentType())));
+
+    } catch (IOException e) {
+      throw new AiException(AiErrorSpec.IMAGE_PROCESS_FAIL, image.getOriginalFilename());
+    }
+
+    return builder.build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
@@ -19,7 +19,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -87,30 +86,6 @@ public class AiClientService {
         .doOnSuccess(result -> log.info("캐릭터 생성 요청을 성공적으로 보냈습니다."))
         .doOnError(error -> log.error("캐릭터 생성 요청에 오류가 발생했습니다.", error))
         .subscribe();
-  }
-
-  private MultiValueMap<String, Object> createMultipartBodys(
-      MultipartFile image, ClientCharacterRequest request) {
-    MultiValueMap<String, Object> multipartBody = new LinkedMultiValueMap<>();
-
-    // 요청 json
-    multipartBody.add("memberId", new HttpEntity<>(request.memberId()));
-    multipartBody.add("characterStyle", new HttpEntity<>(request.characterStyle()));
-
-    // 이미지
-    try {
-      ByteArrayResource imageResource =
-          new ByteArrayResource(image.getBytes()) {
-            @Override
-            public String getFilename() {
-              return image.getOriginalFilename();
-            }
-          };
-      multipartBody.add("userImage", new HttpEntity<>(imageResource));
-    } catch (Exception e) {
-      throw new AiException(AiErrorSpec.IMAGE_PROCESS_FAIL, image.getOriginalFilename());
-    }
-    return multipartBody;
   }
 
   private MultiValueMap<String, HttpEntity<?>> createMultipartBody(

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.ai.client.service;
 
+import com.heartsave.todaktodak_api.ai.client.config.properties.AiServerProperties;
 import com.heartsave.todaktodak_api.ai.client.dto.request.ClientAiCommentRequest;
 import com.heartsave.todaktodak_api.ai.client.dto.request.ClientBgmRequest;
 import com.heartsave.todaktodak_api.ai.client.dto.request.ClientCharacterRequest;
@@ -13,7 +14,6 @@ import java.io.IOException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
@@ -29,15 +29,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 @Service
 public class AiClientService {
-  @Value("${ai.server.url.image-domain}")
-  private String AI_SERVER_IMAGE_URL_DOMAIN;
-
-  @Value("${ai.server.url.text-domain}")
-  private String AI_SERVER_TEXT_URL_DOMAIN;
-
-  @Value("${ai.server.url.bgm-domain}")
-  private String AI_SERVER_BGM_URL_DOMAIN;
-
+  private final AiServerProperties aiServerProperties;
   private final WebClient webClient;
 
   public AiDiaryContentResponse callDiaryContent(DiaryEntity diary) {
@@ -51,7 +43,7 @@ public class AiClientService {
   private void callWebtoon(ClientWebtoonRequest request) {
     webClient
         .post()
-        .uri(AI_SERVER_IMAGE_URL_DOMAIN + "/webtoon")
+        .uri(aiServerProperties.imageDomain() + "/webtoon")
         .bodyValue(request)
         .retrieve()
         .bodyToMono(Void.class)
@@ -63,7 +55,7 @@ public class AiClientService {
   private void callBgm(ClientBgmRequest request) {
     webClient
         .post()
-        .uri(AI_SERVER_BGM_URL_DOMAIN + "/bgm")
+        .uri(aiServerProperties.bgmDomain() + "/bgm")
         .bodyValue(request)
         .retrieve()
         .bodyToMono(Void.class)
@@ -75,7 +67,7 @@ public class AiClientService {
   private String callComment(ClientAiCommentRequest request) {
     return webClient
         .post()
-        .uri(AI_SERVER_TEXT_URL_DOMAIN + "/comment")
+        .uri(aiServerProperties.textDomain() + "/comment")
         .bodyValue(request)
         .retrieve()
         .bodyToMono(String.class)
@@ -87,7 +79,7 @@ public class AiClientService {
   public void callCharacter(MultipartFile image, ClientCharacterRequest request) {
     webClient
         .post()
-        .uri(AI_SERVER_IMAGE_URL_DOMAIN + "/character")
+        .uri(aiServerProperties.imageDomain() + "/character")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .body(BodyInserters.fromMultipartData(createMultipartBody(image, request)))
         .retrieve()

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
@@ -1,6 +1,7 @@
 package com.heartsave.todaktodak_api.ai.client.service;
 
 import com.heartsave.todaktodak_api.ai.client.config.properties.AiServerProperties;
+import com.heartsave.todaktodak_api.ai.client.domain.AiComment;
 import com.heartsave.todaktodak_api.ai.client.dto.request.ClientAiCommentRequest;
 import com.heartsave.todaktodak_api.ai.client.dto.request.ClientBgmRequest;
 import com.heartsave.todaktodak_api.ai.client.dto.request.ClientCharacterRequest;
@@ -36,8 +37,8 @@ public class AiClientService {
     MemberEntity member = diary.getMemberEntity();
     callWebtoon(ClientWebtoonRequest.of(diary, member));
     callBgm(ClientBgmRequest.of(diary, member));
-    String comment = callComment(ClientAiCommentRequest.of((diary)));
-    return AiDiaryContentResponse.builder().aiComment(comment).build();
+    AiComment aiComment = callComment(ClientAiCommentRequest.of((diary)));
+    return AiDiaryContentResponse.builder().aiComment(aiComment.comment()).build();
   }
 
   private void callWebtoon(ClientWebtoonRequest request) {
@@ -64,13 +65,13 @@ public class AiClientService {
         .subscribe();
   }
 
-  private String callComment(ClientAiCommentRequest request) {
+  private AiComment callComment(ClientAiCommentRequest request) {
     return webClient
         .post()
         .uri(aiServerProperties.textDomain() + "/comment")
         .bodyValue(request)
         .retrieve()
-        .bodyToMono(String.class)
+        .bodyToMono(AiComment.class)
         .doOnSuccess(result -> log.info("AI 코멘트 생성 요청을 성공적으로 보냈습니다."))
         .doOnError(error -> log.error("AI 코멘트 생성 요청에 오류가 발생했습니다."))
         .block();

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
@@ -11,6 +11,7 @@ import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
@@ -25,21 +26,29 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 @Service
 public class AiClientService {
+  @Value("${ai.server.url.image-domain}")
+  private String AI_SERVER_IMAGE_URL_DOMAIN;
+
+  @Value("${ai.server.url.text-domain}")
+  private String AI_SERVER_TEXT_URL_DOMAIN;
+
+  @Value("${ai.server.url.bgm-domain}")
+  private String AI_SERVER_BGM_URL_DOMAIN;
 
   private final WebClient webClient;
 
   public AiDiaryContentResponse callDiaryContent(DiaryEntity diary) {
     MemberEntity member = diary.getMemberEntity();
     callWebtoon(ClientWebtoonRequest.of(diary, member));
-    //    callBgm(ClientBgmRequest.of(diary, member));
-    //    String comment = callComment(ClientAiCommentRequest.of((diary)));
-    return AiDiaryContentResponse.builder().aiComment("aiComment").build();
+    callBgm(ClientBgmRequest.of(diary, member));
+    String comment = callComment(ClientAiCommentRequest.of((diary)));
+    return AiDiaryContentResponse.builder().aiComment(comment).build();
   }
 
   private void callWebtoon(ClientWebtoonRequest request) {
     webClient
         .post()
-        .uri("/webtoon")
+        .uri(AI_SERVER_IMAGE_URL_DOMAIN + "/webtoon")
         .bodyValue(request)
         .retrieve()
         .bodyToMono(Void.class)
@@ -51,7 +60,7 @@ public class AiClientService {
   private void callBgm(ClientBgmRequest request) {
     webClient
         .post()
-        .uri("/bgm")
+        .uri(AI_SERVER_BGM_URL_DOMAIN + "/bgm")
         .bodyValue(request)
         .retrieve()
         .bodyToMono(Void.class)
@@ -63,7 +72,7 @@ public class AiClientService {
   private String callComment(ClientAiCommentRequest request) {
     return webClient
         .post()
-        .uri("/comment")
+        .uri(AI_SERVER_TEXT_URL_DOMAIN + "/comment")
         .bodyValue(request)
         .retrieve()
         .bodyToMono(String.class)
@@ -75,7 +84,7 @@ public class AiClientService {
   public void callCharacter(MultipartFile image, ClientCharacterRequest request) {
     webClient
         .post()
-        .uri("/character")
+        .uri(AI_SERVER_IMAGE_URL_DOMAIN + "/character")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .body(BodyInserters.fromMultipartData(createMultipartBody(image, request)))
         .retrieve()

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/service/AiClientService.java
@@ -31,9 +31,9 @@ public class AiClientService {
   public AiDiaryContentResponse callDiaryContent(DiaryEntity diary) {
     MemberEntity member = diary.getMemberEntity();
     callWebtoon(ClientWebtoonRequest.of(diary, member));
-    callBgm(ClientBgmRequest.of(diary, member));
-    String comment = callComment(ClientAiCommentRequest.of((diary)));
-    return AiDiaryContentResponse.builder().aiComment(comment).build();
+    //    callBgm(ClientBgmRequest.of(diary, member));
+    //    String comment = callComment(ClientAiCommentRequest.of((diary)));
+    return AiDiaryContentResponse.builder().aiComment("aiComment").build();
   }
 
   private void callWebtoon(ClientWebtoonRequest request) {

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/WebhookCharacterCompletionRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/dto/request/WebhookCharacterCompletionRequest.java
@@ -15,4 +15,4 @@ public record WebhookCharacterCompletionRequest(
     @NotBlank @Schema(example = "romance", description = "캐릭터 화풍") String characterStyle,
     @NotNull @Positive @Schema(example = "13564", description = "캐릭터 이미지 시드") Integer seedNum,
     @NotBlank @Schema(example = "character/memberId", description = "캐릭터 이미지 경로")
-        String characterUrl) {}
+        String characterProfileImageUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
@@ -3,7 +3,13 @@ package com.heartsave.todaktodak_api.ai.webhook.service;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookBgmCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
+import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
+import com.heartsave.todaktodak_api.event.constant.EventType;
+import com.heartsave.todaktodak_api.event.entity.EventEntity;
+import com.heartsave.todaktodak_api.event.service.EventService;
+import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
+import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +24,8 @@ public class AiDiaryService {
 
   private final AiRepository aiRepository;
   private final S3FileStorageService s3FileStorageService;
-
-  //  private final EventService eventService;
-  //  private final MemberRepository memberRepository;
+  private final EventService eventService;
+  private final MemberRepository memberRepository;
 
   public void saveWebtoon(WebhookWebtoonCompletionRequest request) {
     Long memberId = request.memberId();
@@ -34,8 +39,7 @@ public class AiDiaryService {
     }
     log.info("webtoon url 업데이트를 마쳤습니다.");
     if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
-      // Todo : SSE 알림 구현
-      //      logEventAndNotify(memberId);
+      notify(memberId);
     }
   }
 
@@ -51,22 +55,20 @@ public class AiDiaryService {
     }
     log.info("Bgm url 업데이트를 마쳤습니다. memberId={}", memberId);
     if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
-      // Todo : SSE 알림 구현
-      //      logEventAndNotify(memberId);
+      notify(memberId);
     }
   }
 
-  //  private void logEventAndNotify(Long memberId) {
-  //    var member =
-  //        memberRepository
-  //            .findById(memberId)
-  //            .orElseThrow(() -> new MemberNotFoundException(MemberErrorSpec.NOT_FOUND,
-  // memberId));
-  //    eventService.saveAndSend(
-  //        EventEntity.builder()
-  //            .memberEntity(member)
-  //            .eventName(EventType.DIARY.getType())
-  //            .eventData("일기가 생성됐습니다.")
-  //            .build());
-  //  }
+  private void notify(Long memberId) {
+    var member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new MemberNotFoundException(MemberErrorSpec.NOT_FOUND, memberId));
+    eventService.send(
+        EventEntity.builder()
+            .memberEntity(member)
+            .eventName(EventType.DIARY.getType())
+            .eventData("일기가 생성됐습니다.")
+            .build());
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
@@ -4,16 +4,21 @@ import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookBgmCompletionR
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
 import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Transactional
+@RequiredArgsConstructor
 @Service
 public class AiDiaryService {
 
-  AiRepository aiRepository;
+  private final AiRepository aiRepository;
+
+  //  private final EventService eventService;
+  //  private final MemberRepository memberRepository;
 
   public void saveWebtoon(WebhookWebtoonCompletionRequest request) {
     Long memberId = request.memberId();
@@ -27,6 +32,7 @@ public class AiDiaryService {
     log.info("webtoon url 업데이트를 마쳤습니다.");
     if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
       // Todo : SSE 알림 구현
+      //      logEventAndNotify(memberId);
     }
   }
 
@@ -43,6 +49,21 @@ public class AiDiaryService {
     log.info("Bgm url 업데이트를 마쳤습니다. memberId={}", memberId);
     if (aiRepository.isContentCompleted(memberId, createdDate)) { // Todo : Lock 설정을 통한 동시성 통제
       // Todo : SSE 알림 구현
+      //      logEventAndNotify(memberId);
     }
   }
+
+  //  private void logEventAndNotify(Long memberId) {
+  //    var member =
+  //        memberRepository
+  //            .findById(memberId)
+  //            .orElseThrow(() -> new MemberNotFoundException(MemberErrorSpec.NOT_FOUND,
+  // memberId));
+  //    eventService.saveAndSend(
+  //        EventEntity.builder()
+  //            .memberEntity(member)
+  //            .eventName(EventType.DIARY.getType())
+  //            .eventData("일기가 생성됐습니다.")
+  //            .build());
+  //  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryService.java
@@ -16,8 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AiDiaryService {
 
-  AiRepository aiRepository;
-  S3FileStorageService s3FileStorageService;
+  private final AiRepository aiRepository;
+  private final S3FileStorageService s3FileStorageService;
 
   //  private final EventService eventService;
   //  private final MemberRepository memberRepository;
@@ -25,7 +25,7 @@ public class AiDiaryService {
   public void saveWebtoon(WebhookWebtoonCompletionRequest request) {
     Long memberId = request.memberId();
     LocalDate createdDate = request.createdDate();
-    log.info("webtoon url 업데이트를 시작합니다.");
+    log.info("webtoon url 업데이트를 시작합니다. {}", request.webtoonFolderUrl());
     String keyUrl = s3FileStorageService.parseKeyFrom(request.webtoonFolderUrl());
     int result = aiRepository.updateWebtoonUrl(request, keyUrl);
     if (result == 0) {

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
@@ -38,7 +38,7 @@ public class AiWebhookCharacterService {
         memberRepository
             .findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException(MemberErrorSpec.NOT_FOUND, memberId));
-    String url = s3Service.parseKeyFrom(dto.characterUrl());
+    String url = s3Service.parseKeyFrom(dto.characterProfileImageUrl());
     retrievedMember.updateCharacterInfo(
         dto.characterInfo(), dto.characterStyle(), dto.seedNum(), url);
     return retrievedMember;

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
@@ -22,7 +22,7 @@ public class AiWebhookCharacterService {
   public void saveCharacterAndNotify(WebhookCharacterCompletionRequest dto) {
     MemberEntity member = saveCharacter(dto);
 
-    eventService.saveAndSend(
+    eventService.send(
         EventEntity.builder()
             .memberEntity(member)
             .eventName(EventType.CHARACTER.getType())

--- a/src/main/java/com/heartsave/todaktodak_api/common/config/WebConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/config/WebConfig.java
@@ -2,11 +2,10 @@ package com.heartsave.todaktodak_api.common.config;
 
 import com.heartsave.todaktodak_api.ai.webhook.interceptor.AiServerApiKeyInterceptor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@Configuration
+// @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.heartsave.todaktodak_api.common.exception;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -11,6 +13,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -27,10 +30,24 @@ public class GlobalExceptionHandler {
 
   // 유효성 검사 실패
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidExceptions(MethodArgumentNotValidException e) {
+  public ResponseEntity<ErrorResponse> handleInvalidException(MethodArgumentNotValidException e) {
     var errors = extractValidationErrors(e);
-    logger.error("PARSED ERROR: {}", errors);
+    logger.error("유효성 검사 실패 - 무결성: {}", errors);
     return ResponseEntity.badRequest().body(ErrorResponse.from(errors));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleTypeMismatchException(
+      MethodArgumentTypeMismatchException e) {
+    var errors = extractMisMatchErrors(e);
+    logger.error("유효성 검사 실패 - 타입: {}", errors);
+    return ResponseEntity.badRequest().body(ErrorResponse.from(errors));
+  }
+
+  private Map<String, String> extractMisMatchErrors(MethodArgumentTypeMismatchException e) {
+    Map<String, String> errors = new HashMap<>();
+    errors.put(e.getName(), Objects.requireNonNull(e.getValue()).toString());
+    return errors;
   }
 
   private Map<String, String> extractValidationErrors(BindException e) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/EventErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/EventErrorSpec.java
@@ -1,0 +1,17 @@
+package com.heartsave.todaktodak_api.common.exception.errorspec;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum EventErrorSpec implements ErrorSpec {
+  EVENT_CONNECT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-001", "알림 연결이 실패됐습니다.", "SSE 연결 실패"),
+  EVENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "EVENT-002", "존재하지 않는 알림입니다.", "비정상 이벤트 조회");
+  private final HttpStatus status;
+  private final String code;
+  private final String clientMessage;
+  private final String debugMessage;
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/EventErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/EventErrorSpec.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum EventErrorSpec implements ErrorSpec {
   EVENT_CONNECT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-001", "알림 연결이 실패됐습니다.", "SSE 연결 실패"),
-  EVENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "EVENT-002", "존재하지 않는 알림입니다.", "비정상 이벤트 조회");
+  EVENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "EVENT-002", "존재하지 않는 알림입니다.", "비정상 이벤트 조회"),
+  CONNECTION_TIMEOUT(
+      HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-003", "알림 연결이 실패됐습니다.", "SSE 연결 시간 초과");
   private final HttpStatus status;
   private final String code;
   private final String clientMessage;

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/OAuth2SuccessHandler.java
@@ -14,7 +14,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
 
+@Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -33,6 +35,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     String refreshToken =
         JwtUtils.issueToken((TodakUser) authentication.getPrincipal(), REFRESH_TYPE);
     response.addCookie(CookieUtils.createValidCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken));
-    response.sendRedirect(BASE_URL + ":" + BASE_PORT);
+    response.sendRedirect(BASE_URL + ":" + BASE_PORT + "/home");
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
@@ -35,6 +35,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
   private final TodakOauth2UserDetailsService oauth2UserDetailsService;
   private final AuthenticationEntryPointImpl authenticationEntryPoint;
+  private final OAuth2SuccessHandler oAuth2SuccessHandler;
   private final ObjectMapper objectMapper;
 
   @Value("${todak.cors.allowed-origin}")
@@ -56,7 +57,7 @@ public class SecurityConfig {
             (oauth2) ->
                 oauth2
                     .userInfoEndpoint((config) -> config.userService(oauth2UserDetailsService))
-                    .successHandler(new OAuth2SuccessHandler())
+                    .successHandler(oAuth2SuccessHandler)
                     .failureHandler(new Oauth2FailureHandler(objectMapper)))
         .authorizeHttpRequests(
             authorize ->
@@ -101,6 +102,6 @@ public class SecurityConfig {
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
-    return (web) -> web.ignoring().requestMatchers("/api/v1/ai/webhook/**");
+    return (web) -> web.ignoring().requestMatchers("/api/v1/ai/webhook/**", "/favicon.ico");
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
@@ -67,7 +67,8 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/swagger-resources/**",
                         "/v3/api-docs/**",
-                        "/api/v1/webhook/ai/**")
+                        "/api/v1/webhook/ai/**",
+                        "/error")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/diary/my")
                     .hasAnyRole("USER", "ADMIN")

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageService.java
@@ -31,15 +31,15 @@ public class S3FileStorageService {
 
     List<String> s3ImageUrls = new ArrayList<>();
     String folderUrl = s3FolderUrl.getFirst();
-    for (int order = 1; order <= s3FolderUrl.size(); order++) {
-      s3ImageUrls.add(folderUrl + "/" + order + ".webp");
+    for (int order = 1; order <= 4; order++) {
+      s3ImageUrls.add(folderUrl + order + ".webp");
     }
 
     return s3ImageUrls.stream().map(this::preSign).toList();
   }
 
   public String preSignedFirstWebtoonUrlFrom(String key) {
-    return key == null ? preSign(s3Properties.defaultKey().webtoon()) : preSign(key + "/1.webp");
+    return key == null ? preSign(s3Properties.defaultKey().webtoon()) : preSign(key + "1.webp");
   }
 
   public String preSignedCharacterImageUrlFrom(String key) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageService.java
@@ -62,7 +62,7 @@ public class S3FileStorageService {
     } catch (MalformedURLException e) {
       throw new InvalidS3UrlException(S3ErrorSpec.INVALID_S3_URL, url);
     }
-    return path;
+    return path.substring(1);
   }
 
   // TODO: presigned url 캐싱 관리

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -118,8 +118,7 @@ public class DiaryController {
           @Valid
           @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.")
           @RequestParam("date")
-          LocalDateTime requestDate) {
-    return ResponseEntity.status(HttpStatus.OK)
-        .body(diaryService.getDiary(principal, requestDate.toLocalDate()));
+          LocalDate requestDate) {
+    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(principal, requestDate));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -118,8 +118,8 @@ public class DiaryController {
           @Valid
           @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.")
           @RequestParam("date")
-          @DateTimeFormat(pattern = "yyyy-MM-dd")
-          LocalDate requestDate) {
-    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(principal, requestDate));
+          LocalDateTime requestDate) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(diaryService.getDiary(principal, requestDate.toLocalDate()));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
@@ -13,10 +13,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -73,10 +72,9 @@ public class MySharedDiaryController {
               schema = @Schema(type = "string", format = "date"))
           @Valid
           @PastOrPresent
-          @DateTimeFormat(pattern = "yyyy-MM-dd")
           @RequestParam("date")
-          LocalDate requestDate) {
+          LocalDateTime requestDate) {
     return ResponseEntity.status(HttpStatus.OK)
-        .body(mySharedDiaryService.getDiary(principal, requestDate));
+        .body(mySharedDiaryService.getDiary(principal, requestDate.toLocalDate()));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/PublicDiary.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/PublicDiary.java
@@ -31,7 +31,7 @@ public class PublicDiary {
       description = "일기 내용을 기반으로 생성된 웹툰 이미지 URL 목록",
       example =
           "[\"/webtoon/1/2024/11/06/1.webp\",\"/webtoon/1/2024/11/06/2.webp\",\"/webtoon/1/2024/11/06/3.webp\",\"/webtoon/1/2024/11/06/4.webp\"]")
-  private final List<String> webtoonUrls;
+  private final List<String> webtoonImageUrls;
 
   @Schema(description = "배경음악 URL", example = "/music-ai/1/2024/11/06/1.mp3")
   private final String bgmUrl;
@@ -61,7 +61,7 @@ public class PublicDiary {
     this.characterImageUrl = content.getCharacterImageUrl();
     this.nickname = content.getNickname();
     this.publicContent = content.getPublicContent();
-    this.webtoonUrls = content.getWebtoonImageUrls();
+    this.webtoonImageUrls = content.getWebtoonImageUrls();
     this.bgmUrl = content.getBgmUrl();
     this.createdDate = content.getDate();
     this.reactionCount = reactionCount;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryIndexProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryIndexProjection.java
@@ -1,10 +1,9 @@
 package com.heartsave.todaktodak_api.diary.entity.projection;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 @Schema(description = "연월 일기 작성 현황 API 응답 데이터")
 public interface DiaryIndexProjection {
@@ -13,6 +12,6 @@ public interface DiaryIndexProjection {
   Long getId();
 
   @JsonProperty("date")
-  @DateTimeFormat(iso = ISO.DATE_TIME)
+  @JsonFormat(pattern = "yyyy-MM-dd")
   LocalDateTime getDiaryCreatedTime();
 }

--- a/src/main/java/com/heartsave/todaktodak_api/event/constant/EventType.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/constant/EventType.java
@@ -1,0 +1,13 @@
+package com.heartsave.todaktodak_api.event.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+  DIARY("diary"),
+  CHARACTER("character");
+
+  private final String type;
+}

--- a/src/main/java/com/heartsave/todaktodak_api/event/controller/SseEventController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/controller/SseEventController.java
@@ -2,6 +2,11 @@ package com.heartsave.todaktodak_api.event.controller;
 
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.event.service.SseEventService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -17,10 +22,31 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/v1/event")
 public class SseEventController {
   private final SseEventService eventService;
-  private final Long SSE_TIMEOUT_MILLI_SECOND = 120 * 1000L;
+  private final long SSE_TIMEOUT_MILLI_SECOND = 120 * 1000L;
 
+  @Operation(summary = "SSE 이벤트 수신을 위한 연결")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "연결 성공",
+            content =
+                @Content(
+                    examples = {
+                      @ExampleObject(
+                          name = "연결 성공 이벤트",
+                          description = "초기 연결 성공시 전송되는 이벤트",
+                          value =
+                              """
+                                 id: memberId_timestamp
+                                 event: connect
+                                 data: 이벤트 수신 연결 성공
+                                 """)
+                    })),
+        @ApiResponse(responseCode = "500", description = "연결 실패 또는 시간초과")
+      })
   @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter subscribe(@AuthenticationPrincipal TodakUser principal) {
+  public SseEmitter connect(@AuthenticationPrincipal TodakUser principal) {
     return eventService.connect(principal.getId(), SSE_TIMEOUT_MILLI_SECOND);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/event/controller/SseEventController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/controller/SseEventController.java
@@ -1,0 +1,26 @@
+package com.heartsave.todaktodak_api.event.controller;
+
+import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.event.service.SseEventService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "알림", description = "클라이언트에게 알림 이벤트를 전송합니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/event")
+public class SseEventController {
+  private final SseEventService eventService;
+  private final Long SSE_TIMEOUT_MILLI_SECOND = 120 * 1000L;
+
+  @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@AuthenticationPrincipal TodakUser principal) {
+    return eventService.connect(principal.getId(), SSE_TIMEOUT_MILLI_SECOND);
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/event/entity/EventEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/entity/EventEntity.java
@@ -1,4 +1,4 @@
-package com.heartsave.todaktodak_api.notification.entity;
+package com.heartsave.todaktodak_api.event.entity;
 
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/heartsave/todaktodak_api/event/exception/EventException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/exception/EventException.java
@@ -1,0 +1,15 @@
+package com.heartsave.todaktodak_api.event.exception;
+
+import com.heartsave.todaktodak_api.common.exception.BaseException;
+import com.heartsave.todaktodak_api.common.exception.ErrorFieldBuilder;
+import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
+
+public class EventException extends BaseException {
+  public EventException(ErrorSpec errorSpec) {
+    super(errorSpec, null);
+  }
+
+  public EventException(ErrorSpec errorSpec, Long memberId) {
+    super(errorSpec, ErrorFieldBuilder.builder().add("memberId", memberId).build());
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/event/repository/EventRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/repository/EventRepository.java
@@ -1,8 +1,17 @@
 package com.heartsave.todaktodak_api.event.repository;
 
 import com.heartsave.todaktodak_api.event.entity.EventEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EventRepository extends JpaRepository<EventEntity, String> {}
+public interface EventRepository extends JpaRepository<EventEntity, String> {
+  @Query(
+      "SELECT e FROM EventEntity e "
+          + "WHERE e.memberEntity.id = :memberId "
+          + "ORDER BY e.createdTime ASC")
+  List<EventEntity> findAllEventsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/heartsave/todaktodak_api/event/repository/EventRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/repository/EventRepository.java
@@ -1,0 +1,8 @@
+package com.heartsave.todaktodak_api.event.repository;
+
+import com.heartsave.todaktodak_api.event.entity.EventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventRepository extends JpaRepository<EventEntity, String> {}

--- a/src/main/java/com/heartsave/todaktodak_api/event/repository/SseEmitterRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/repository/SseEmitterRepository.java
@@ -1,0 +1,30 @@
+package com.heartsave.todaktodak_api.event.repository;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class SseEmitterRepository {
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  // key: 회원 ID
+  private final ConcurrentHashMap<Long, SseEmitter> emitterRepository = new ConcurrentHashMap<>();
+
+  public SseEmitter save(Long memberId, SseEmitter emitter) {
+    emitterRepository.put(memberId, emitter);
+    logger.info("회원 {}의 Emitter 추가", memberId);
+    return emitter;
+  }
+
+  public void delete(Long memberId) {
+    emitterRepository.remove(memberId);
+    logger.info("회원 {}의 Emitter 삭제", memberId);
+  }
+
+  public Optional<SseEmitter> get(Long memberId) {
+    return Optional.ofNullable(emitterRepository.get(memberId));
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/event/repository/SseEmitterRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/repository/SseEmitterRepository.java
@@ -13,7 +13,7 @@ public class SseEmitterRepository {
   // key: 회원 ID
   private final ConcurrentHashMap<Long, SseEmitter> emitterRepository = new ConcurrentHashMap<>();
 
-  public SseEmitter save(Long memberId, SseEmitter emitter) {
+  public SseEmitter save(SseEmitter emitter, Long memberId) {
     emitterRepository.put(memberId, emitter);
     logger.info("회원 {}의 Emitter 추가", memberId);
     return emitter;

--- a/src/main/java/com/heartsave/todaktodak_api/event/service/EventService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/service/EventService.java
@@ -1,0 +1,14 @@
+package com.heartsave.todaktodak_api.event.service;
+
+import com.heartsave.todaktodak_api.event.entity.EventEntity;
+
+public interface EventService {
+  void save(EventEntity event);
+
+  void send(EventEntity event);
+
+  default void saveAndSend(EventEntity event) {
+    save(event);
+    send(event);
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/event/service/SseEventService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/service/SseEventService.java
@@ -31,6 +31,8 @@ public class SseEventService implements EventService {
     eventRepository.save(event);
   }
 
+  // 연결되어 있으면 이벤트를 전송하고,
+  // 그렇지 않으면 이벤트를 저장한다.
   @Override
   public void send(EventEntity event) {
     emitterRepository
@@ -120,6 +122,9 @@ public class SseEventService implements EventService {
     emitter.complete();
     emitterRepository.delete(memberId);
     logger.info("SSE 연결 종료. memberId={} reason={}", memberId, reason);
+
+    if (TIMEOUT_MESSAGE.equals(reason))
+      throw new EventException(EventErrorSpec.CONNECTION_TIMEOUT, memberId);
   }
 
   private void handleEmitterError(Long memberId, Exception e) {

--- a/src/main/java/com/heartsave/todaktodak_api/event/service/SseEventService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/service/SseEventService.java
@@ -1,0 +1,121 @@
+package com.heartsave.todaktodak_api.event.service;
+
+import com.heartsave.todaktodak_api.event.entity.EventEntity;
+import com.heartsave.todaktodak_api.event.repository.EventRepository;
+import com.heartsave.todaktodak_api.event.repository.SseEmitterRepository;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SseEventService implements EventService {
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final EventRepository eventRepository;
+  private final SseEmitterRepository emitterRepository;
+  private static final String CONNECT_EVENT_NAME = "connect";
+  private static final String CONNECT_MESSAGE = "이벤트 수신 연결 성공";
+  private static final String TIMEOUT_MESSAGE = "시간 초과";
+  private static final String COMPLETION_MESSAGE = "전송 완료 또는 재접속";
+
+  @Override
+  public void save(EventEntity event) {
+    eventRepository.save(event);
+  }
+
+  @Override
+  public void send(EventEntity event) {
+    emitterRepository
+        .get(event.getMemberEntity().getId())
+        .ifPresentOrElse(
+            emitter -> sendEvent(emitter, event),
+            () -> logEmitterNotFound(event.getMemberEntity().getId()));
+  }
+
+  private void sendEvent(SseEmitter emitter, EventEntity event) {
+    try {
+      emitter.send(createEvent(event));
+      logEventSuccess(event);
+    } catch (IOException e) {
+      handleEmitterError(event.getMemberEntity().getId(), e);
+    }
+  }
+
+  private SseEmitter.SseEventBuilder createEvent(EventEntity event) {
+    return SseEmitter.event()
+        .id(event.getId())
+        .name(event.getEventName())
+        .data(event.getEventData());
+  }
+
+  public SseEmitter connect(Long memberId, Long timeout) {
+    disconnectExistingEmitter(memberId);
+    SseEmitter emitter = createEmitter(timeout);
+    setEmitterCallbacks(emitter, memberId);
+
+    if (!sendInitialEvent(emitter)) {
+      return null;
+    }
+
+    return emitterRepository.save(memberId, emitter);
+  }
+
+  private void disconnectExistingEmitter(Long memberId) {
+    emitterRepository
+        .get(memberId)
+        .ifPresent(
+            emitter -> {
+              emitter.complete();
+              emitterRepository.delete(memberId);
+            });
+  }
+
+  private SseEmitter createEmitter(Long timeout) {
+    return new SseEmitter(timeout);
+  }
+
+  private void setEmitterCallbacks(SseEmitter emitter, Long memberId) {
+    emitter.onTimeout(() -> handleEmitterComplete(emitter, memberId, TIMEOUT_MESSAGE));
+    emitter.onCompletion(() -> handleEmitterComplete(emitter, memberId, COMPLETION_MESSAGE));
+    emitter.onError(e -> handleEmitterError(memberId, (Exception) e));
+  }
+
+  private boolean sendInitialEvent(SseEmitter emitter) {
+    try {
+      emitter.send(SseEmitter.event().name(CONNECT_EVENT_NAME).data(CONNECT_MESSAGE));
+      return true;
+    } catch (IOException e) {
+      handleEmitterError(null, e);
+      return false;
+    }
+  }
+
+  private void handleEmitterComplete(SseEmitter emitter, Long memberId, String reason) {
+    emitter.complete();
+    emitterRepository.delete(memberId);
+    logger.info("{}로 인한 SSE 연결. memberId = {}", reason, memberId);
+  }
+
+  private void handleEmitterError(Long memberId, Exception e) {
+    if (memberId != null) {
+      emitterRepository.delete(memberId);
+    }
+    logger.error("SSE 에러 발생. memberId = {}, error = {}", memberId, e.getMessage());
+  }
+
+  private void logEventSuccess(EventEntity event) {
+    logger.info(
+        "이벤트 전송 완료. memberId = {}, eventName = {}",
+        event.getMemberEntity().getId(),
+        event.getEventName());
+  }
+
+  private void logEmitterNotFound(Long memberId) {
+    logger.warn("연결된 Emitter 없음. memberId = {}", memberId);
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
@@ -1,6 +1,5 @@
 package com.heartsave.todaktodak_api.member.controller;
 
-import com.heartsave.todaktodak_api.ai.client.dto.request.ClientCharacterRequest;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterRegisterResponse;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterTemporaryImageResponse;
@@ -40,8 +39,9 @@ public class CharacterController {
       })
   @PostMapping
   public ResponseEntity<Void> createCharacterImage(
-      @RequestParam("uploadImage") MultipartFile file, ClientCharacterRequest dto) {
-    characterService.createCharacterImage(file, dto);
+      @RequestParam("uploadImage") MultipartFile file,
+      @AuthenticationPrincipal TodakUser principal) {
+    characterService.createCharacterImage(file, principal);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
@@ -40,10 +40,8 @@ public class CharacterController {
       })
   @PostMapping
   public ResponseEntity<Void> createCharacterImage(
-      @AuthenticationPrincipal TodakUser principal,
-      @RequestParam("uploadImage") MultipartFile file,
-      ClientCharacterRequest dto) {
-    characterService.createCharacterImage(principal, file, dto);
+      @RequestParam("uploadImage") MultipartFile file, ClientCharacterRequest dto) {
+    characterService.createCharacterImage(file, dto);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
@@ -38,8 +38,7 @@ public class CharacterService {
         .build();
   }
 
-  public void createCharacterImage(
-      TodakUser principal, MultipartFile file, ClientCharacterRequest dto) {
+  public void createCharacterImage(MultipartFile file, ClientCharacterRequest dto) {
     aiClientService.callCharacter(file, dto);
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
@@ -38,7 +38,10 @@ public class CharacterService {
         .build();
   }
 
-  public void createCharacterImage(MultipartFile file, ClientCharacterRequest dto) {
+  public void createCharacterImage(MultipartFile file, TodakUser principal) {
+    MemberEntity member = findMemberByPrincipal(principal);
+    ClientCharacterRequest dto =
+        ClientCharacterRequest.builder().characterStyle("romance").memberId(member.getId()).build();
     aiClientService.callCharacter(file, dto);
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/notification/entity/EventEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/notification/entity/EventEntity.java
@@ -1,0 +1,38 @@
+package com.heartsave.todaktodak_api.notification.entity;
+
+import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@Table(name = "event")
+public class EventEntity {
+  @Id private String id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity memberEntity;
+
+  @Column(updatable = false)
+  private String eventName;
+
+  @Column(updatable = false)
+  private String eventData;
+
+  @CreatedDate
+  @Column(updatable = false, columnDefinition = "TIMESTAMP(3)")
+  private LocalDateTime createdTime;
+
+  @PrePersist
+  public void generateId() {
+    if (this.id == null) this.id = memberEntity.getId() + "_" + System.currentTimeMillis();
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,9 +104,9 @@ todak:
 ai:
   server:
     url:
-      image-domain: ${AI_SERVER_IMAGE_URL_DOMAIN}
-      text-domain: ${AI_SERVER_TEXT_URL_DOMAIN}
-      bgm-domain: ${AI_SERVER_BGM_URL_DOMAIN}
+      image-domain: ${AI_SERVER_IMAGE_URL_DOMAIN:ai-domain}
+      text-domain: ${AI_SERVER_TEXT_URL_DOMAIN:ai-domain}
+      bgm-domain: ${AI_SERVER_BGM_URL_DOMAIN:ai-domain}
     api:
       key: ${AI_SERVER_API_KEY:default-api-key}
 ---
@@ -126,8 +126,8 @@ todak:
 ai:
   server:
     url:
-      image-domain: ${AI_SERVER_IMAGE_URL_DOMAIN}
-      text-domain: ${AI_SERVER_TEXT_URL_DOMAIN}
-      bgm-domain: ${AI_SERVER_BGM_URL_DOMAIN}
+      image-domain: ${AI_SERVER_IMAGE_URL_DOMAIN:ai-domain}
+      text-domain: ${AI_SERVER_TEXT_URL_DOMAIN:ai-domain}
+      bgm-domain: ${AI_SERVER_BGM_URL_DOMAIN:ai-domain}
     api:
       key: "test-api-key"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,7 +104,9 @@ todak:
 ai:
   server:
     url:
-      domain: ${AI_SERVER_URL_DOMAIN}
+      image-domain: ${AI_SERVER_IMAGE_URL_DOMAIN}
+      text-domain: ${AI_SERVER_TEXT_URL_DOMAIN}
+      bgm-domain: ${AI_SERVER_BGM_URL_DOMAIN}
     api:
       key: ${AI_SERVER_API_KEY:default-api-key}
 ---
@@ -124,6 +126,8 @@ todak:
 ai:
   server:
     url:
-      domain: "test-ai-server-url-domain"
+      image-domain: ${AI_SERVER_IMAGE_URL_DOMAIN}
+      text-domain: ${AI_SERVER_TEXT_URL_DOMAIN}
+      bgm-domain: ${AI_SERVER_BGM_URL_DOMAIN}
     api:
       key: "test-api-key"

--- a/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
@@ -29,7 +29,7 @@ class AiClientServiceTest {
   private static final String WEBTOON_URI = "/webtoon";
   private static final String BGM_URI = "/bgm";
   private static final String COMMENT_URI = "/comment";
-  private static final String AI_COMMENT = "this is ai comment";
+  private static final String AI_COMMENT = "aiComment";
 
   @BeforeAll
   static void setUp() throws IOException {

--- a/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
@@ -45,7 +45,10 @@ class AiClientServiceTest {
               case WEBTOON_URI, BGM_URI:
                 return new MockResponse();
               case COMMENT_URI:
-                return new MockResponse().setResponseCode(200).setBody(AI_COMMENT);
+                return new MockResponse()
+                    .setResponseCode(200)
+                    .setBody("{\"comment\": \"" + AI_COMMENT + "\"}")
+                    .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
               default:
                 return new MockResponse().setResponseCode(404);
             }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/client/service/AiClientServiceTest.java
@@ -2,6 +2,7 @@ package com.heartsave.todaktodak_api.ai.client.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.heartsave.todaktodak_api.ai.client.config.properties.AiServerProperties;
 import com.heartsave.todaktodak_api.ai.client.dto.response.AiDiaryContentResponse;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
@@ -26,6 +27,7 @@ class AiClientServiceTest {
 
   private static MockWebServer mockWebServer;
   private static AiClientService aiClientService;
+  private static AiServerProperties aiServerProperties;
   private static final String WEBTOON_URI = "/webtoon";
   private static final String BGM_URI = "/bgm";
   private static final String COMMENT_URI = "/comment";
@@ -50,13 +52,14 @@ class AiClientServiceTest {
           }
         });
 
-    String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
+    String AI_URL = String.format("http://localhost:%s", mockWebServer.getPort());
+    aiServerProperties = new AiServerProperties(AI_URL, AI_URL, AI_URL);
+
     WebClient aiWebClient =
         WebClient.builder()
-            .baseUrl(baseUrl)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .build();
-    aiClientService = new AiClientService(aiWebClient);
+    aiClientService = new AiClientService(aiServerProperties, aiWebClient);
   }
 
   @AfterAll

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
@@ -197,7 +197,7 @@ class AiWebhookControllerTest {
               .memberId(member.getId())
               .characterInfo(member.getCharacterInfo())
               .characterStyle(member.getCharacterStyle())
-              .characterUrl(member.getCharacterImageUrl())
+              .characterProfileImageUrl(member.getCharacterImageUrl())
               .seedNum(member.getCharacterSeed())
               .build();
 
@@ -229,7 +229,7 @@ class AiWebhookControllerTest {
               .memberId(memberId)
               .characterInfo(characterInfo)
               .characterStyle(characterStyle)
-              .characterUrl(characterUrl)
+              .characterProfileImageUrl(characterUrl)
               .seedNum(seedNum)
               .build();
 
@@ -268,7 +268,7 @@ class AiWebhookControllerTest {
               .memberId(member.getId())
               .characterInfo(member.getCharacterInfo())
               .characterStyle(member.getCharacterStyle())
-              .characterUrl(member.getCharacterImageUrl())
+              .characterProfileImageUrl(member.getCharacterImageUrl())
               .seedNum(member.getCharacterSeed())
               .build();
 

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/interceptor/AiServerApiKeyInterceptorTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/interceptor/AiServerApiKeyInterceptorTest.java
@@ -11,6 +11,7 @@ import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonComplet
 import com.heartsave.todaktodak_api.ai.webhook.service.AiDiaryService;
 import com.heartsave.todaktodak_api.ai.webhook.service.AiWebhookCharacterService;
 import com.heartsave.todaktodak_api.ai.webhook.test_config.TestInterceptorSecurityConfig;
+import com.heartsave.todaktodak_api.common.config.WebConfig;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AiErrorSpec;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +27,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest({AiWebhookController.class})
 @AutoConfigureMockMvc
-@Import(TestInterceptorSecurityConfig.class)
+@Import({TestInterceptorSecurityConfig.class, WebConfig.class})
 class AiServerApiKeyInterceptorTest {
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiDiaryServiceTest.java
@@ -9,7 +9,11 @@ import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookBgmCompletionR
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.repository.AiRepository;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
+import com.heartsave.todaktodak_api.event.service.EventService;
+import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,6 +28,8 @@ class AiDiaryServiceTest {
 
   @Mock private AiRepository aiRepository;
   @Mock private S3FileStorageService s3FileStorageService;
+  @Mock private MemberRepository memberRepository;
+  @Mock private EventService eventService;
   @InjectMocks private AiDiaryService aiDiaryService;
 
   private WebhookWebtoonCompletionRequest webtoonRequest;
@@ -58,6 +64,7 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("웹툰 URL 업데이트 성공 및 AI 컨텐츠 생성이 완료된 경우")
     void saveWebtoon_UpdateSuccessAndCustomBgmUrl() {
+      when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mock(MemberEntity.class)));
       when(aiRepository.updateWebtoonUrl(webtoonRequest, parseKeyUrl)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(true);
 
@@ -99,6 +106,7 @@ class AiDiaryServiceTest {
     @Test
     @DisplayName("BGM URL 업데이트 성공 및 AI 컨텐츠 생성이 완료된 경우")
     void saveBgm_UpdateSuccessAndAiContentCompleted() {
+      when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mock(MemberEntity.class)));
       when(aiRepository.updateBgmUrl(bgmRequest, parseKeyUrl)).thenReturn(1);
       when(aiRepository.isContentCompleted(memberId, createdDate)).thenReturn(true);
 

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
@@ -5,14 +5,20 @@ import static org.mockito.Mockito.*;
 
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookCharacterCompletionRequest;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
+import com.heartsave.todaktodak_api.common.exception.errorspec.EventErrorSpec;
+import com.heartsave.todaktodak_api.event.constant.EventType;
+import com.heartsave.todaktodak_api.event.entity.EventEntity;
+import com.heartsave.todaktodak_api.event.exception.EventException;
 import com.heartsave.todaktodak_api.event.service.EventService;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -40,21 +46,50 @@ final class AiWebhookCharacterServiceTest {
   }
 
   @Test
-  void saveCharacterAndNotify() {
+  @DisplayName("캐릭터 웹훅에 대한 알림 성공")
+  void saveCharacterAndNotify_success() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    ArgumentCaptor<EventEntity> eventCaptor = ArgumentCaptor.forClass(EventEntity.class);
 
     // when
     characterService.saveCharacterAndNotify(request);
 
     // then
     verify(memberRepository).findById(member.getId());
+    verify(eventService).send(eventCaptor.capture());
+
+    // 회원 정보 변경
     assertEquals(request.characterInfo(), member.getCharacterInfo());
     assertEquals(request.characterStyle(), member.getCharacterStyle());
     assertEquals(request.seedNum(), member.getCharacterSeed());
+
+    // 알림 메시지
+    EventEntity capturedEvent = eventCaptor.getValue();
+    assertAll(
+        () -> assertEquals(member, capturedEvent.getMemberEntity()),
+        () -> assertEquals(EventType.CHARACTER.getType(), capturedEvent.getEventName()));
   }
 
   @Test
+  @DisplayName("캐릭터 웹훅에 대한 알림 실패 - 이벤트 전송 오류")
+  void saveCharacterAndNotify_eventSendFail() {
+    // given
+    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    doThrow(new EventException(EventErrorSpec.EVENT_CONNECT_FAIL))
+        .when(eventService)
+        .send(any(EventEntity.class));
+
+    // when
+    assertThrows(EventException.class, () -> characterService.saveCharacterAndNotify(request));
+
+    // then
+    verify(memberRepository).findById(member.getId());
+    verify(eventService).send(any(EventEntity.class));
+  }
+
+  @Test
+  @DisplayName("캐릭터 웹훅에 대한 알림 실패 - 존재하지 않는 회원")
   void saveCharacterAndNotify_memberNotFound() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.empty());
@@ -64,5 +99,6 @@ final class AiWebhookCharacterServiceTest {
         MemberNotFoundException.class, () -> characterService.saveCharacterAndNotify(request));
 
     verify(memberRepository).findById(member.getId());
+    verify(eventService, never()).send(any(EventEntity.class));
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
@@ -5,8 +5,8 @@ import static org.mockito.Mockito.*;
 
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookCharacterCompletionRequest;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
-import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.common.exception.errorspec.EventErrorSpec;
+import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.event.constant.EventType;
 import com.heartsave.todaktodak_api.event.entity.EventEntity;
 import com.heartsave.todaktodak_api.event.exception.EventException;
@@ -41,7 +41,7 @@ final class AiWebhookCharacterServiceTest {
         WebhookCharacterCompletionRequest.builder()
             .characterInfo(member.getCharacterInfo())
             .characterStyle(member.getCharacterStyle())
-            .characterUrl(member.getCharacterImageUrl())
+            .characterProfileImageUrl(member.getCharacterImageUrl())
             .memberId(member.getId())
             .seedNum(member.getCharacterSeed())
             .build();

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookCharacterCompletionRequest;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
+import com.heartsave.todaktodak_api.event.service.EventService;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 final class AiWebhookCharacterServiceTest {
   @Mock private MemberRepository memberRepository;
+  @Mock private EventService eventService;
   @InjectMocks private AiWebhookCharacterService characterService;
 
   private MemberEntity member;

--- a/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
@@ -207,7 +207,7 @@ final class S3FileStorageServiceTest {
       List<String> presignedUrls = s3Service.preSignedWebtoonUrlFrom(folderUrls);
 
       // then
-      assertThat(presignedUrls).hasSize(1).allMatch(url -> url.equals(TEST_PRE_SIGNED_URL));
+      assertThat(presignedUrls).hasSize(4).allMatch(url -> url.equals(TEST_PRE_SIGNED_URL));
     }
   }
 

--- a/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/storage/S3FileStorageServiceTest.java
@@ -230,7 +230,7 @@ final class S3FileStorageServiceTest {
 
     private final String VALID_S3_URL =
         "https://" + TEST_BUCKET + ".s3.amazonaws.com/path/to/file.jpg";
-    private final String EXPECTED_KEY = "/path/to/file.jpg";
+    private final String EXPECTED_KEY = "path/to/file.jpg";
 
     @Test
     @DisplayName("유효한 S3 URL에서 키 추출 성공")

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryControllerTest.java
@@ -22,6 +22,7 @@ import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreview
 import com.heartsave.todaktodak_api.diary.exception.PublicDiaryNotFoundException;
 import com.heartsave.todaktodak_api.diary.service.MySharedDiaryService;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -170,8 +171,8 @@ public class MySharedDiaryControllerTest {
                 return 1L;
               }
             });
-    LocalDate now = LocalDate.now();
-    when(diaryResponse.getDiaryCreatedDate()).thenReturn(now);
+    LocalDateTime now = LocalDateTime.now();
+    when(diaryResponse.getDiaryCreatedDate()).thenReturn(now.toLocalDate());
     when(mockMySharedDiaryService.getDiary(any(TodakUser.class), any(LocalDate.class)))
         .thenReturn(diaryResponse);
 
@@ -246,10 +247,11 @@ public class MySharedDiaryControllerTest {
   @WithMockTodakUser
   @DisplayName("존재하지 않는 날짜의 일기 조회시 404 응답")
   void getMySharedDiary_WithNonExistentDate_NotFound() throws Exception {
-    LocalDate now = LocalDate.now();
+    LocalDateTime now = LocalDateTime.now();
     when(mockMySharedDiaryService.getDiary(any(TodakUser.class), any(LocalDate.class)))
         .thenThrow(
-            new PublicDiaryNotFoundException(PublicDiaryErrorSpec.PUBLIC_DIARY_NOT_FOUND, now));
+            new PublicDiaryNotFoundException(
+                PublicDiaryErrorSpec.PUBLIC_DIARY_NOT_FOUND, now.toLocalDate()));
 
     mockMvc
         .perform(

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
@@ -227,8 +227,8 @@ class PublicDiaryServiceTest {
               assertThat(diary.getPublicDiaryId()).isEqualTo(publicDiaryId);
               assertThat(diary.getDiaryId()).isEqualTo(this.diary.getId());
               assertThat(diary.getCharacterImageUrl()).isEqualTo("character/image.jpg");
-              assertThat(diary.getWebtoonUrls().getFirst()).isEqualTo("webtoon/image.jpg");
-              assertThat(diary.getWebtoonUrls().size()).isEqualTo(1);
+              assertThat(diary.getWebtoonImageUrls().getFirst()).isEqualTo("webtoon/image.jpg");
+              assertThat(diary.getWebtoonImageUrls().size()).isEqualTo(1);
               assertThat(diary.getBgmUrl()).isEqualTo("bgm/music.mp3");
               assertThat(diary.getNickname()).isEqualTo("nickname");
               assertThat(diary.getPublicContent()).isEqualTo("content");

--- a/src/test/java/com/heartsave/todaktodak_api/event/repository/SseEmitterRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/event/repository/SseEmitterRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.heartsave.todaktodak_api.event.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+final class SseEmitterRepositoryTest {
+  private SseEmitterRepository emitterRepository;
+  private SseEmitter sseEmitter;
+  private static final Long MEMBER_ID = 1L;
+
+  @BeforeEach
+  void setUp() {
+    emitterRepository = new SseEmitterRepository();
+    sseEmitter = new SseEmitter();
+  }
+
+  @Test
+  @DisplayName("연결 관리를 위한 Emitter 저장 성공")
+  void saveTest() {
+    // when
+    SseEmitter savedEmitter = emitterRepository.save(sseEmitter, MEMBER_ID);
+
+    // then
+    assertThat(savedEmitter).isEqualTo(sseEmitter);
+  }
+
+  @Test
+  @DisplayName("연결 종료로 인한 Emitter 삭제 성공")
+  void deleteTest() {
+    // given
+    emitterRepository.save(sseEmitter, MEMBER_ID);
+
+    // when
+    emitterRepository.delete(MEMBER_ID);
+    Optional<SseEmitter> result = emitterRepository.get(MEMBER_ID);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("연결된 회원의 Emitter 조회")
+  void get_existedMember() {
+    // given
+    emitterRepository.save(sseEmitter, MEMBER_ID);
+
+    // when
+    Optional<SseEmitter> result = emitterRepository.get(MEMBER_ID);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(sseEmitter);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 회원의 Emitter 조회")
+  void get_nonExistedMember() {
+    // when
+    Optional<SseEmitter> result = emitterRepository.get(MEMBER_ID);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/java/com/heartsave/todaktodak_api/event/service/SseEventServiceSuccessTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/event/service/SseEventServiceSuccessTest.java
@@ -1,0 +1,126 @@
+package com.heartsave.todaktodak_api.event.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.heartsave.todaktodak_api.common.BaseTestObject;
+import com.heartsave.todaktodak_api.event.entity.EventEntity;
+import com.heartsave.todaktodak_api.event.repository.EventRepository;
+import com.heartsave.todaktodak_api.event.repository.SseEmitterRepository;
+import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class SseEventServiceSuccessTest {
+  @Mock private EventRepository eventRepository;
+  @Mock private SseEmitterRepository emitterRepository;
+  @InjectMocks private SseEventService sseEventService;
+
+  @Mock private SseEmitter emitter;
+  private MemberEntity member;
+  private EventEntity event;
+
+  private final long TEST_TIMEOUT = 60000L;
+
+  @BeforeEach
+  void setup() {
+    member = BaseTestObject.createMember();
+    event = EventEntity.builder().memberEntity(member).build();
+  }
+
+  @Test
+  @DisplayName("이벤트 저장")
+  void saveTest() {
+    // given
+    when(eventRepository.save(any(EventEntity.class))).thenReturn(event);
+
+    // when
+    sseEventService.save(event);
+
+    // then
+    verify(eventRepository, times(1)).save(event);
+  }
+
+  @Test
+  @DisplayName("이벤트 전송 - Emitter가 존재하는 경우")
+  void send_existedEmitter() throws Exception {
+    // given
+    when(emitterRepository.get(anyLong())).thenReturn(Optional.of(emitter));
+
+    // when
+    sseEventService.send(event);
+
+    // then
+    verify(emitter, times(1)).send(any(SseEmitter.SseEventBuilder.class));
+  }
+
+  @Test
+  @DisplayName("이벤트 전송 - Emitter가 존재하지 않으면 이벤트를 저장한다.")
+  void send_noEmitter_saveEvent() {
+    // given
+    when(emitterRepository.get(anyLong())).thenReturn(Optional.empty());
+
+    // when
+    sseEventService.send(event);
+
+    // then
+    verify(eventRepository, times(1)).save(event);
+  }
+
+  @Test
+  @DisplayName("SSE 연결")
+  void connectTest() {
+    // given
+    when(emitterRepository.save(any(SseEmitter.class), eq(member.getId()))).thenReturn(emitter);
+    when(eventRepository.findAllEventsByMemberId(eq(member.getId())))
+        .thenReturn(Collections.emptyList());
+
+    // when
+    SseEmitter result = sseEventService.connect(member.getId(), TEST_TIMEOUT);
+
+    // then
+    assertNotNull(result);
+    verify(emitterRepository, times(1)).save(any(SseEmitter.class), eq(member.getId()));
+  }
+
+  @Test
+  @DisplayName("기존 연결 해제")
+  void disconnect_existedEmitter() {
+    // given
+    when(emitterRepository.get(eq(member.getId()))).thenReturn(Optional.of(emitter));
+
+    // when
+    sseEventService.connect(member.getId(), TEST_TIMEOUT);
+
+    // then
+    verify(emitter, times(1)).complete();
+    verify(emitterRepository, times(1)).delete(member.getId());
+  }
+
+  @Test
+  @DisplayName("과거 이벤트 전송")
+  void sendPastEventTest() {
+    // given
+    List<EventEntity> pastEvents = Arrays.asList(event, event); // 2개를 수신하지 못한 상황
+    when(eventRepository.findAllEventsByMemberId(anyLong())).thenReturn(pastEvents);
+    when(emitterRepository.save(any(SseEmitter.class), anyLong())).thenReturn(emitter);
+
+    // when
+    sseEventService.connect(member.getId(), TEST_TIMEOUT);
+
+    // then
+    verify(eventRepository, times(1)).findAllEventsByMemberId(member.getId());
+    verify(eventRepository, times(pastEvents.size())).delete(event);
+  }
+}


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항
## SSE API 구현

### Postman으로 SSE를 연결한 모습
![Screenshot 2024-11-08 at 1 52 10 AM](https://github.com/user-attachments/assets/efa8189b-4610-418e-b177-34b79538e4f9)


Flow는 다음과 같습니다.

1. 클라이언트가 SSE 연결을 요청한다.
2. 이벤트를 전송하기 위해 `Emitter` 객체를 생성하고 관리한다.
3. 웹훅 발동시 이벤트를 전송한다.
    1. 만약, 연결이 되어있지 않거나 전송 오류시 DB에 이벤트를 저장한다.
    2. 재연결시 미수신한 이벤트(DB에 있는 이벤트)를 전송받을 수 있다.
    3. DB에 있던 이벤트가 전송되면 DB에서 삭제된다.

예를 들어, **캐릭터 생성 웹훅**에 대해 아래의 시퀀스처럼 동작이 됩니다.

[![](https://mermaid.ink/img/pako:eNqlVk1P20AQ_Ssrn1oRgijtxQekiqKqh_bQVOolF5MsYDWxU7OJhBASahyEIEhIbcpHAk1KSj8EqglGohW_KDv-D93YcWzv2iioOUSRd96b2TdvxlmTcnoeS7K0gt-XsZbDz1RlyVCKWQ2xT0kxiJpTS4pG0FxBxRoRn89X2OM5XSOGXihgIyagqBKCjde4pK-oRDdWxZCnLzLYqMSB3-KFZV1_NzhWc1g8f4mLC3dzu_Ul4t1THv5KJxjprJ7hpVPcHWU0nUaZzDyCfavfsxCYXWg3EN350b8yPQoPODk7OyFgn8-_QVNKSZ2qTE_hykhTLs6F8srJqH9jQcf2NUXQsZyj-pCAj55kHJNCeh9KrQPn8AA9gJMtutOlP-2HHo33rRSImMuGk3PvOL7gMeptt_qXlseBtXw441h0UN0KcW3AybcksNcAWWzTuC0epakeg3mJ4NCkp_UEsO9fGT1KMzMj-LtHzy4c0xqhjz5B7yLeIQEYPt_2r20Exzb9fQPfN1jhNdpp0Y8tD-JHRkFcrjtCMzOwvxemDynI38xHpcLzI6OZtD-SCHoH9Ow8cqdQ1ono5MoxmriKImj-cZo1Dx_FDFj4-ZYR8zs09yLO54Nc4_P5fVy7Qa_sofsTsopJQ8V7-EFndi0mpbN9Ey9glDXl-_Fx2m1Ar8uACBp1enYbkVCUINoAUcaArW3CZmfotdBc8FyRi4XQ3DjFLZKgDDc6MhUJGcUhvufyGuWMbi5-W925poKC_D4k2pGTc7irCis4yLC_Ccf1IEPQc04joTPbXefDdfL286uMs2-IzJu7sPScaQb40T3d8YoDiStQbNWTdHgP0l81OL1lKx317Q1GF4jvb9ivNVfDnVagzmjPCRs2ArrneyX2hTJoklNlxjShYUKzypzSYmVH6_k_erZA6ZfzZOLAaOOyankpJRWxUVTUPPsftjZ4nJXIMi7irCSzn3m8qJQLJCtltXUWqpSJnlnVcpJMjDJOSYZeXlqW5EWFlZeSyqW8Qvw_cV7I-j_6KSmH?type=png)](https://mermaid.live/edit#pako:eNqlVk1P20AQ_Ssrn1oRgijtxQekiqKqh_bQVOolF5MsYDWxU7OJhBASahyEIEhIbcpHAk1KSj8EqglGohW_KDv-D93YcWzv2iioOUSRd96b2TdvxlmTcnoeS7K0gt-XsZbDz1RlyVCKWQ2xT0kxiJpTS4pG0FxBxRoRn89X2OM5XSOGXihgIyagqBKCjde4pK-oRDdWxZCnLzLYqMSB3-KFZV1_NzhWc1g8f4mLC3dzu_Ul4t1THv5KJxjprJ7hpVPcHWU0nUaZzDyCfavfsxCYXWg3EN350b8yPQoPODk7OyFgn8-_QVNKSZ2qTE_hykhTLs6F8srJqH9jQcf2NUXQsZyj-pCAj55kHJNCeh9KrQPn8AA9gJMtutOlP-2HHo33rRSImMuGk3PvOL7gMeptt_qXlseBtXw441h0UN0KcW3AybcksNcAWWzTuC0epakeg3mJ4NCkp_UEsO9fGT1KMzMj-LtHzy4c0xqhjz5B7yLeIQEYPt_2r20Exzb9fQPfN1jhNdpp0Y8tD-JHRkFcrjtCMzOwvxemDynI38xHpcLzI6OZtD-SCHoH9Ow8cqdQ1ono5MoxmriKImj-cZo1Dx_FDFj4-ZYR8zs09yLO54Nc4_P5fVy7Qa_sofsTsopJQ8V7-EFndi0mpbN9Ey9glDXl-_Fx2m1Ar8uACBp1enYbkVCUINoAUcaArW3CZmfotdBc8FyRi4XQ3DjFLZKgDDc6MhUJGcUhvufyGuWMbi5-W925poKC_D4k2pGTc7irCis4yLC_Ccf1IEPQc04joTPbXefDdfL286uMs2-IzJu7sPScaQb40T3d8YoDiStQbNWTdHgP0l81OL1lKx317Q1GF4jvb9ivNVfDnVagzmjPCRs2ArrneyX2hTJoklNlxjShYUKzypzSYmVH6_k_erZA6ZfzZOLAaOOyankpJRWxUVTUPPsftjZ4nJXIMi7irCSzn3m8qJQLJCtltXUWqpSJnlnVcpJMjDJOSYZeXlqW5EWFlZeSyqW8Qvw_cV7I-j_6KSmH)

## 주요 객체

### EventEntity

클라이언트가 수신하지 못한 이벤트를 저장하기 위한 객체입니다.

### EventRepository

특정 사용자가 수신하지 못한 모든 이벤트를 조회할 수 있습니다.

### SseEmitterRepository

이벤트 전송을 담당하는 `Emitter` 를 관리하는 레포지토리 객체입니다.

### EventService(Interface)와 SseEventService(Impl)

- `save` , `send`, `saveAndSend` 가 제공됩니다.

## 테스트

1. 캐릭터 웹훅 서비스 - 알림 전송 관련
2. `SseEmitterRepository`
4. `SseEventService` - **연결 실패 관련 테스트 추가 필요**
5. `SseEventController` **- 미진행, MockMvc의 비동기 관련 에러 원인 확인중**

## 리뷰 받고 싶은 내용
두 가지를 중점으로 살펴주시면 감사하겠습니다.
1. 웹훅 서비스가 이벤트를 적절한 시점에 전송하는가? (`AiDiaryService`는 주석으로 처리해두었습니다.)
2. SSE의 이벤트 저장(`save`)과 전달(`send`)의 흐름이 맞는가?
`save`의 경우: 클라이언트와 연결하지 않은 상태에서 이벤트 호출된 경우
`send`의 경우: 클라이언트와 연결됐을 때 이벤트 호출 OR 수신하지 못한 이벤트를 전달하는 경우

## 테스트 및 결과
- 로컬 테스트 완료

## 관련 스크린샷 및 참고자료 (Optional)
close #96 