### PR TITLE
Feature/todak 236/auth id annotation

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/auth/annotation/TodakUserId.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/annotation/TodakUserId.java
@@ -1,0 +1,10 @@
+package com.heartsave.todaktodak_api.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TodakUserId {}

--- a/src/main/java/com/heartsave/todaktodak_api/auth/annotation/TodakUserIdResolver.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/annotation/TodakUserIdResolver.java
@@ -1,0 +1,37 @@
+package com.heartsave.todaktodak_api.auth.annotation;
+
+import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import java.util.Optional;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class TodakUserIdResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(TodakUserId.class)
+        && parameter.getParameterType().equals(Long.class);
+  }
+
+  @Override
+  public Long resolveArgument(
+      MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    return Optional.ofNullable(authentication)
+        .filter(Authentication::isAuthenticated)
+        .map(Authentication::getPrincipal)
+        .filter(principal -> principal instanceof TodakUser)
+        .map(TodakUser.class::cast)
+        .map(TodakUser::getId)
+        .orElseThrow(() -> new AuthenticationCredentialsNotFoundException("인증 정보를 찾을 수 없습니다."));
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/config/WebConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/config/WebConfig.java
@@ -1,11 +1,15 @@
 package com.heartsave.todaktodak_api.common.config;
 
 import com.heartsave.todaktodak_api.ai.webhook.interceptor.AiServerApiKeyInterceptor;
+import com.heartsave.todaktodak_api.auth.annotation.TodakUserIdResolver;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-// @Configuration
+@Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
@@ -14,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(aiServerApiKeyInterceptor).addPathPatterns("/api/v1/webhook/ai/**");
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new TodakUserIdResolver());
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -1,6 +1,6 @@
 package com.heartsave.todaktodak_api.diary.controller;
 
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.auth.annotation.TodakUserId;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryResponse;
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,10 +48,9 @@ public class DiaryController {
       })
   @PostMapping
   public ResponseEntity<DiaryWriteResponse> writeDiary(
-      @AuthenticationPrincipal TodakUser principal,
-      @Valid @RequestBody DiaryWriteRequest writeRequest) {
+      @TodakUserId Long memberId, @Valid @RequestBody DiaryWriteRequest writeRequest) {
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(diaryService.write(principal, writeRequest));
+        .body(diaryService.write(memberId, writeRequest));
   }
 
   @Operation(summary = "일기 삭제")
@@ -63,7 +61,7 @@ public class DiaryController {
       })
   @DeleteMapping("/{diaryId}")
   public ResponseEntity<Void> deleteDiary(
-      @AuthenticationPrincipal TodakUser principal,
+      @TodakUserId Long memberId,
       @Parameter(
               name = "diaryId",
               description = "삭제할 일기 ID",
@@ -74,7 +72,7 @@ public class DiaryController {
           @PathVariable
           @Min(value = 1, message = "diaryId의 값은 최소 1 이상이어야 합니다.")
           Long diaryId) {
-    diaryService.delete(principal, diaryId);
+    diaryService.delete(memberId, diaryId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
@@ -86,7 +84,7 @@ public class DiaryController {
       })
   @GetMapping
   public ResponseEntity<DiaryIndexResponse> getDiaryIndex(
-      @AuthenticationPrincipal TodakUser principal,
+      @TodakUserId Long memberId,
       @Parameter(
               name = "yearMonth",
               description = "조회할 연월",
@@ -96,7 +94,7 @@ public class DiaryController {
           @RequestParam("yearMonth")
           @DateTimeFormat(pattern = "yyyy-MM")
           YearMonth yearMonth) {
-    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getIndex(principal, yearMonth));
+    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getIndex(memberId, yearMonth));
   }
 
   @Operation(summary = "일기 상세 조회")
@@ -108,7 +106,7 @@ public class DiaryController {
       })
   @GetMapping("/detail")
   public ResponseEntity<DiaryResponse> getDiary(
-      @AuthenticationPrincipal TodakUser principal,
+      @TodakUserId Long memberId,
       @Parameter(
               name = "date",
               description = "조회할 일기의 날짜",
@@ -119,6 +117,6 @@ public class DiaryController {
           @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.")
           @RequestParam("date")
           LocalDate requestDate) {
-    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(principal, requestDate));
+    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(memberId, requestDate));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
@@ -1,6 +1,6 @@
 package com.heartsave.todaktodak_api.diary.controller;
 
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.auth.annotation.TodakUserId;
 import com.heartsave.todaktodak_api.diary.dto.response.MySharedDiaryPaginationResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.MySharedDiaryResponse;
 import com.heartsave.todaktodak_api.diary.service.MySharedDiaryService;
@@ -18,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,7 +40,7 @@ public class MySharedDiaryController {
       })
   @GetMapping
   public ResponseEntity<MySharedDiaryPaginationResponse> getMySharedDiaryPagination(
-      @AuthenticationPrincipal TodakUser principal,
+      @TodakUserId Long memberId,
       @Parameter(
               name = "after",
               description = "마지막으로 조회된 공개 일기 ID",
@@ -52,7 +51,7 @@ public class MySharedDiaryController {
           @RequestParam(name = "after", defaultValue = "0")
           Long publicDiaryId) {
     return ResponseEntity.status(HttpStatus.OK)
-        .body(mySharedDiaryService.getPagination(principal, publicDiaryId));
+        .body(mySharedDiaryService.getPagination(memberId, publicDiaryId));
   }
 
   @Operation(summary = "특정 날짜의 나의 공개된 일기 상세 조회")
@@ -64,7 +63,7 @@ public class MySharedDiaryController {
       })
   @GetMapping("/detail")
   public ResponseEntity<MySharedDiaryResponse> getMySharedDiary(
-      @AuthenticationPrincipal TodakUser principal,
+      @TodakUserId Long memberId,
       @Parameter(
               name = "date",
               description = "조회할 일기 날짜",
@@ -75,6 +74,6 @@ public class MySharedDiaryController {
           @RequestParam("date")
           LocalDateTime requestDate) {
     return ResponseEntity.status(HttpStatus.OK)
-        .body(mySharedDiaryService.getDiary(principal, requestDate.toLocalDate()));
+        .body(mySharedDiaryService.getDiary(memberId, requestDate.toLocalDate()));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
@@ -1,6 +1,6 @@
 package com.heartsave.todaktodak_api.diary.controller;
 
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.auth.annotation.TodakUserId;
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.PublicDiaryPaginationResponse;
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,12 +41,12 @@ public class PublicDiaryController {
       })
   @GetMapping
   public ResponseEntity<PublicDiaryPaginationResponse> getPublicDiaries(
-      @AuthenticationPrincipal TodakUser principal,
+      @TodakUserId Long memberId,
       @Valid @Min(0L) @RequestParam(name = "after", defaultValue = "0", required = false)
           Long publicDiaryId) {
     log.info("공개 일기를 조회를 요청합니다. after = {}", publicDiaryId);
     PublicDiaryPaginationResponse response =
-        publicDiaryService.getPublicDiaryPagination(principal, publicDiaryId);
+        publicDiaryService.getPublicDiaryPagination(memberId, publicDiaryId);
     log.info("공개 일기 조회를 성공적으로 마쳤습니다.");
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
@@ -60,11 +59,11 @@ public class PublicDiaryController {
       })
   @PostMapping
   public ResponseEntity<Void> writePublicContent(
-      @AuthenticationPrincipal TodakUser principal,
+      @TodakUserId Long memberId,
       @Parameter(description = "일기 공개 업로드 요청 데이터", required = true) @Valid @RequestBody
           PublicDiaryWriteRequest request) {
     log.info("공개 일기 업로드 시작");
-    publicDiaryService.write(principal, request.publicContent(), request.diaryId());
+    publicDiaryService.write(memberId, request.publicContent(), request.diaryId());
     log.info("공개 일기 업로드 성공");
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
@@ -79,11 +78,11 @@ public class PublicDiaryController {
       })
   @PostMapping("/reaction")
   public ResponseEntity<Void> toggleReaction(
-      @Parameter(hidden = true) @AuthenticationPrincipal TodakUser principal,
+      @Parameter(hidden = true) @TodakUserId Long memberId,
       @Parameter(description = "일기 반응 요청 데이터", required = true) @Valid @RequestBody
           PublicDiaryReactionRequest request) {
     log.info("일기장 반응 토글을 요청합니다");
-    publicDiaryService.toggleReactionStatus(principal, request);
+    publicDiaryService.toggleReactionStatus(memberId, request);
     log.info("일기장 반응 토글을 성공적으로 마쳤습니다.");
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
@@ -1,7 +1,6 @@
 package com.heartsave.todaktodak_api.diary.service;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.PublicDiaryErrorSpec;
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.dto.response.MySharedDiaryPaginationResponse;
@@ -30,9 +29,8 @@ public class MySharedDiaryService {
   private final DiaryReactionRepository reactionRepository;
   private final S3FileStorageService s3FileStorageService;
 
-  public MySharedDiaryPaginationResponse getPagination(TodakUser principal, Long publicDiaryId) {
+  public MySharedDiaryPaginationResponse getPagination(Long memberId, Long publicDiaryId) {
     log.info("나의 공개된 일기 정보를 요청합니다.");
-    Long memberId = principal.getId();
     List<MySharedDiaryPreviewProjection> previews = fetchPreviews(memberId, publicDiaryId);
     replaceWithPreSignedUrls(previews);
     log.info("나의 공개된 일기 정보 요청을 성공적으로 마쳤습니다.");
@@ -57,9 +55,8 @@ public class MySharedDiaryService {
     }
   }
 
-  public MySharedDiaryResponse getDiary(TodakUser principal, LocalDate requestDate) {
+  public MySharedDiaryResponse getDiary(Long memberId, LocalDate requestDate) {
     log.info("나의 공개된 일기 상세 정보를 요청합니다.");
-    Long memberId = principal.getId();
     MySharedDiaryContentOnlyProjection contentOnly = fetchContentOnly(requestDate, memberId);
     replaceWithPreSignedUrls(contentOnly);
 

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryService.java
@@ -1,7 +1,6 @@
 package com.heartsave.todaktodak_api.diary.service;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.dto.PublicDiary;
@@ -34,9 +33,7 @@ public class PublicDiaryService {
   private final DiaryReactionRepository diaryReactionRepository;
   private final S3FileStorageService s3FileStorageService;
 
-  public PublicDiaryPaginationResponse getPublicDiaryPagination(
-      TodakUser principal, Long publicDiaryId) {
-    Long memberId = principal.getId();
+  public PublicDiaryPaginationResponse getPublicDiaryPagination(Long memberId, Long publicDiaryId) {
     List<PublicDiaryContentOnlyProjection> diaryContents = fetchDiaryContents(publicDiaryId);
     replaceWithPreSignedUrls(diaryContents);
     return createPaginationResponse(diaryContents, memberId);
@@ -88,8 +85,7 @@ public class PublicDiaryService {
     return diaryReactionRepository.findMemberReaction(memberId, diaryId);
   }
 
-  public void write(TodakUser principal, String publicContent, Long diaryId) {
-    Long memberId = principal.getId();
+  public void write(Long memberId, String publicContent, Long diaryId) {
     DiaryEntity diary =
         diaryRepository
             .findById(diaryId) // Todo : exist 로 최적화
@@ -105,8 +101,7 @@ public class PublicDiaryService {
     publicDiaryRepository.save(publicDiary);
   }
 
-  public void toggleReactionStatus(TodakUser principal, PublicDiaryReactionRequest request) {
-    Long memberId = principal.getId();
+  public void toggleReactionStatus(Long memberId, PublicDiaryReactionRequest request) {
     Long diaryId = request.diaryId();
     DiaryReactionType reactionType = request.reactionType();
     DiaryReactionEntity reactionEntity = getDiaryReactionEntity(memberId, diaryId, reactionType);

--- a/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
@@ -1,6 +1,6 @@
 package com.heartsave.todaktodak_api.member.controller;
 
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.auth.annotation.TodakUserId;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterRegisterResponse;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterTemporaryImageResponse;
 import com.heartsave.todaktodak_api.member.service.CharacterService;
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,8 +27,8 @@ public class CharacterController {
       })
   @GetMapping
   public ResponseEntity<CharacterTemporaryImageResponse> getPastCharacterImage(
-      @AuthenticationPrincipal TodakUser principal) {
-    return ResponseEntity.ok(characterService.getPastCharacterImage(principal));
+      @TodakUserId Long memberId) {
+    return ResponseEntity.ok(characterService.getPastCharacterImage(memberId));
   }
 
   @ApiResponses(
@@ -39,9 +38,8 @@ public class CharacterController {
       })
   @PostMapping
   public ResponseEntity<Void> createCharacterImage(
-      @RequestParam("uploadImage") MultipartFile file,
-      @AuthenticationPrincipal TodakUser principal) {
-    characterService.createCharacterImage(file, principal);
+      @RequestParam("uploadImage") MultipartFile file, @TodakUserId Long memberId) {
+    characterService.createCharacterImage(file, memberId);
     return ResponseEntity.noContent().build();
   }
 
@@ -52,7 +50,7 @@ public class CharacterController {
       })
   @PostMapping("/register")
   public ResponseEntity<CharacterRegisterResponse> completeCharacterRegister(
-      @AuthenticationPrincipal TodakUser principal, HttpServletResponse response) {
-    return ResponseEntity.ok(characterService.changeRoleAndReissueToken(principal, response));
+      @TodakUserId Long memberId, HttpServletResponse response) {
+    return ResponseEntity.ok(characterService.changeRoleAndReissueToken(memberId, response));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/controller/MemberController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.heartsave.todaktodak_api.member.controller;
 
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
+import com.heartsave.todaktodak_api.auth.annotation.TodakUserId;
 import com.heartsave.todaktodak_api.member.dto.request.NicknameUpdateRequest;
 import com.heartsave.todaktodak_api.member.dto.response.MemberProfileResponse;
 import com.heartsave.todaktodak_api.member.dto.response.NicknameUpdateResponse;
@@ -12,7 +12,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원", description = "회원 API")
@@ -30,8 +29,8 @@ public class MemberController {
         @ApiResponse(responseCode = "404", description = "회원 조회 실패")
       })
   public ResponseEntity<NicknameUpdateResponse> updateNickname(
-      @AuthenticationPrincipal TodakUser user, @Valid @RequestBody NicknameUpdateRequest dto) {
-    return ResponseEntity.ok(memberService.updateNickname(user, dto));
+      @TodakUserId Long memberId, @Valid @RequestBody NicknameUpdateRequest dto) {
+    return ResponseEntity.ok(memberService.updateNickname(memberId, dto));
   }
 
   @GetMapping("/profile")
@@ -40,9 +39,8 @@ public class MemberController {
         @ApiResponse(responseCode = "200", description = "회원 프로필 조회"),
         @ApiResponse(responseCode = "404", description = "회원 조회 실패")
       })
-  public ResponseEntity<MemberProfileResponse> getMemberProfile(
-      @AuthenticationPrincipal TodakUser user) {
-    return ResponseEntity.ok(memberService.getMemberProfileById(user));
+  public ResponseEntity<MemberProfileResponse> getMemberProfile(@TodakUserId Long memberId) {
+    return ResponseEntity.ok(memberService.getMemberProfile(memberId));
   }
 
   @PostMapping("/deactivate")
@@ -51,9 +49,8 @@ public class MemberController {
         @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공"),
         @ApiResponse(responseCode = "404", description = "회원 조회 실패")
       })
-  public ResponseEntity<Void> deactivate(
-      @AuthenticationPrincipal TodakUser user, HttpServletResponse response) {
-    memberService.deactivate(response, user);
+  public ResponseEntity<Void> deactivate(@TodakUserId Long memberId, HttpServletResponse response) {
+    memberService.deactivate(response, memberId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/service/MemberService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/service/MemberService.java
@@ -4,7 +4,6 @@ import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.
 import static com.heartsave.todaktodak_api.common.security.util.CookieUtils.*;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.member.dto.request.NicknameUpdateRequest;
 import com.heartsave.todaktodak_api.member.dto.response.MemberProfileResponse;
@@ -25,15 +24,15 @@ public class MemberService {
   private final MemberRepository memberRepository;
   private final S3FileStorageService s3Service;
 
-  public NicknameUpdateResponse updateNickname(TodakUser principal, NicknameUpdateRequest dto) {
-    MemberEntity retrievedMember = findMemberById(principal.getId());
+  public NicknameUpdateResponse updateNickname(Long memberId, NicknameUpdateRequest dto) {
+    MemberEntity retrievedMember = findMemberById(memberId);
     retrievedMember.updateNickname(dto.nickname());
     return NicknameUpdateResponse.builder().nickname(retrievedMember.getNickname()).build();
   }
 
   @Transactional(readOnly = true)
-  public MemberProfileResponse getMemberProfileById(TodakUser principal) {
-    MemberProfileProjection memberProfile = getMemberProfileById(principal.getId());
+  public MemberProfileResponse getMemberProfile(Long memberId) {
+    MemberProfileProjection memberProfile = getMemberProfileById(memberId);
 
     String characterPreSignedUrl =
         s3Service.preSignedCharacterImageUrlFrom(memberProfile.getCharacterImageUrl());
@@ -45,8 +44,8 @@ public class MemberService {
         .build();
   }
 
-  public void deactivate(HttpServletResponse response, TodakUser principal) {
-    MemberEntity retrievedMember = findMemberById(principal.getId());
+  public void deactivate(HttpServletResponse response, Long memberId) {
+    MemberEntity retrievedMember = findMemberById(memberId);
     memberRepository.delete(retrievedMember);
     updateCookie(response, createExpiredCookie(REFRESH_TOKEN_COOKIE_KEY));
   }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/interceptor/AiServerApiKeyInterceptorTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/interceptor/AiServerApiKeyInterceptorTest.java
@@ -11,7 +11,6 @@ import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonComplet
 import com.heartsave.todaktodak_api.ai.webhook.service.AiDiaryService;
 import com.heartsave.todaktodak_api.ai.webhook.service.AiWebhookCharacterService;
 import com.heartsave.todaktodak_api.ai.webhook.test_config.TestInterceptorSecurityConfig;
-import com.heartsave.todaktodak_api.common.config.WebConfig;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AiErrorSpec;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest({AiWebhookController.class})
 @AutoConfigureMockMvc
-@Import({TestInterceptorSecurityConfig.class, WebConfig.class})
+@Import({TestInterceptorSecurityConfig.class})
 class AiServerApiKeyInterceptorTest {
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
@@ -17,7 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.security.WithMockTodakUser;
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
@@ -61,7 +60,7 @@ public class DiaryControllerTest {
 
     final String AI_COMMENT = "this is test ai comment";
 
-    when(diaryService.write(any(TodakUser.class), any(DiaryWriteRequest.class)))
+    when(diaryService.write(anyLong(), any(DiaryWriteRequest.class)))
         .thenReturn(DiaryWriteResponse.builder().aiComment(AI_COMMENT).build());
     MvcResult mvcResult =
         mockMvc
@@ -73,7 +72,7 @@ public class DiaryControllerTest {
             .andDo(print())
             .andReturn();
 
-    verify(diaryService, times(1)).write(any(TodakUser.class), any(DiaryWriteRequest.class));
+    verify(diaryService, times(1)).write(anyLong(), any(DiaryWriteRequest.class));
     MockHttpServletResponse response = mvcResult.getResponse();
     assertThat(response.getContentAsString()).contains(AI_COMMENT);
   }
@@ -83,28 +82,29 @@ public class DiaryControllerTest {
   @WithMockTodakUser
   @ValueSource(longs = {1L, Long.MAX_VALUE, 25234L})
   void deleteDiarySuccess(Long diaryId) throws Exception {
-    doNothing().when(diaryService).delete(any(TodakUser.class), anyLong());
+    doNothing().when(diaryService).delete(anyLong(), anyLong());
     MvcResult mvcResult =
         mockMvc
             .perform(delete("/api/v1/diary/my/" + diaryId))
             .andExpect(status().isNoContent())
             .andDo(print())
             .andReturn();
-    verify(diaryService, times(1)).delete(any(TodakUser.class), anyLong());
+    verify(diaryService, times(1)).delete(anyLong(), anyLong());
   }
 
+  @WithMockTodakUser
   @ParameterizedTest
   @DisplayName("일기 삭제 요청 실패 - 매개변수 검증 실패")
   @ValueSource(longs = {0L, -1L, -123124L})
   void deleteDiaryFailByParameterValidation(Long diaryId) throws Exception {
-    doNothing().when(diaryService).delete(any(TodakUser.class), anyLong());
+    doNothing().when(diaryService).delete(anyLong(), anyLong());
     MvcResult mvcResult =
         mockMvc
             .perform(delete("/api/v1/diary/my/" + diaryId))
             .andExpect(status().isBadRequest())
             .andDo(print())
             .andReturn();
-    verify(diaryService, times(0)).delete(any(TodakUser.class), anyLong());
+    verify(diaryService, times(0)).delete(anyLong(), anyLong());
   }
 
   @DisplayName("연월 일기 작성 현황 요청 성공")
@@ -117,8 +117,7 @@ public class DiaryControllerTest {
         DiaryIndexResponse.builder().diaryIndexes(mockIndexes).build();
 
     // when
-    when(diaryService.getIndex(any(TodakUser.class), any(YearMonth.class)))
-        .thenReturn(mockResponse);
+    when(diaryService.getIndex(anyLong(), any(YearMonth.class))).thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult =
@@ -148,8 +147,7 @@ public class DiaryControllerTest {
     DiaryIndexResponse mockResponse = new DiaryIndexResponse(new ArrayList<>());
 
     // when
-    when(diaryService.getIndex(any(TodakUser.class), any(YearMonth.class)))
-        .thenReturn(mockResponse);
+    when(diaryService.getIndex(anyLong(), any(YearMonth.class))).thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult =
@@ -177,8 +175,7 @@ public class DiaryControllerTest {
             .build();
 
     // when
-    when(diaryService.getDiary(any(TodakUser.class), any(LocalDate.class)))
-        .thenReturn(mockResponse);
+    when(diaryService.getDiary(anyLong(), any(LocalDate.class))).thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult =
@@ -206,6 +203,7 @@ public class DiaryControllerTest {
         .andDo(print());
   }
 
+  @WithMockTodakUser
   @ParameterizedTest
   @DisplayName("일기 상세 조회 실패 - 잘못된 날짜 형식")
   @ValueSource(

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryControllerTest.java
@@ -71,7 +71,7 @@ public class MySharedDiaryControllerTest {
   @WithMockTodakUser
   @DisplayName("공개된 일기 목록 조회 성공")
   void getMySharedDiaryPreviews_Success() throws Exception {
-    when(mockMySharedDiaryService.getPagination(any(TodakUser.class), anyLong()))
+    when(mockMySharedDiaryService.getPagination(anyLong(), anyLong()))
         .thenReturn(paginationResponse);
     MvcResult mvcResult =
         mockMvc
@@ -83,7 +83,7 @@ public class MySharedDiaryControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.sharedDiaries").exists())
             .andReturn();
-    verify(mockMySharedDiaryService, times(1)).getPagination(any(TodakUser.class), anyLong());
+    verify(mockMySharedDiaryService, times(1)).getPagination(anyLong(), anyLong());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class MySharedDiaryControllerTest {
   @WithMockTodakUser
   @DisplayName("빈 목록 조회 성공")
   void getMySharedDiaryPreviews_EmptyList_Success() throws Exception {
-    when(mockMySharedDiaryService.getPagination(any(TodakUser.class), anyLong()))
+    when(mockMySharedDiaryService.getPagination(anyLong(), anyLong()))
         .thenReturn(MySharedDiaryPaginationResponse.of(List.of()));
 
     mockMvc
@@ -122,7 +122,7 @@ public class MySharedDiaryControllerTest {
   @WithMockTodakUser
   @DisplayName("after 파라미터 없이 요청시 기본값 0으로 성공")
   void getMySharedDiaryPreviews_WithoutAfterParam_Success() throws Exception {
-    when(mockMySharedDiaryService.getPagination(any(TodakUser.class), anyLong()))
+    when(mockMySharedDiaryService.getPagination(anyLong(), anyLong()))
         .thenReturn(paginationResponse);
 
     mockMvc
@@ -173,7 +173,7 @@ public class MySharedDiaryControllerTest {
             });
     LocalDateTime now = LocalDateTime.now();
     when(diaryResponse.getDiaryCreatedDate()).thenReturn(now.toLocalDate());
-    when(mockMySharedDiaryService.getDiary(any(TodakUser.class), any(LocalDate.class)))
+    when(mockMySharedDiaryService.getDiary(anyLong(), any(LocalDate.class)))
         .thenReturn(diaryResponse);
 
     MvcResult mvcResult =
@@ -202,7 +202,7 @@ public class MySharedDiaryControllerTest {
             webtoonImageUrls.get(2),
             webtoonImageUrls.get(3));
 
-    verify(mockMySharedDiaryService, times(1)).getDiary(any(TodakUser.class), any(LocalDate.class));
+    verify(mockMySharedDiaryService, times(1)).getDiary(anyLong(), any(LocalDate.class));
   }
 
   @Test
@@ -248,7 +248,7 @@ public class MySharedDiaryControllerTest {
   @DisplayName("존재하지 않는 날짜의 일기 조회시 404 응답")
   void getMySharedDiary_WithNonExistentDate_NotFound() throws Exception {
     LocalDateTime now = LocalDateTime.now();
-    when(mockMySharedDiaryService.getDiary(any(TodakUser.class), any(LocalDate.class)))
+    when(mockMySharedDiaryService.getDiary(anyLong(), any(LocalDate.class)))
         .thenThrow(
             new PublicDiaryNotFoundException(
                 PublicDiaryErrorSpec.PUBLIC_DIARY_NOT_FOUND, now.toLocalDate()));

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryControllerTest.java
@@ -1,6 +1,7 @@
 package com.heartsave.todaktodak_api.diary.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -12,7 +13,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.security.WithMockTodakUser;
-import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.dto.PublicDiary;
 import com.heartsave.todaktodak_api.diary.dto.request.PublicDiaryReactionRequest;
@@ -44,7 +44,7 @@ public class PublicDiaryControllerTest {
     String content = "테스트 공개 일기 내용";
     PublicDiaryWriteRequest request = new PublicDiaryWriteRequest(diaryId, content);
 
-    doNothing().when(publicDiaryService).write(any(TodakUser.class), eq(content), eq(diaryId));
+    doNothing().when(publicDiaryService).write(anyLong(), eq(content), eq(diaryId));
 
     mockMvc
         .perform(
@@ -80,7 +80,7 @@ public class PublicDiaryControllerTest {
 
     doNothing()
         .when(publicDiaryService)
-        .toggleReactionStatus(any(TodakUser.class), any(PublicDiaryReactionRequest.class));
+        .toggleReactionStatus(anyLong(), any(PublicDiaryReactionRequest.class));
 
     mockMvc
         .perform(
@@ -147,7 +147,7 @@ public class PublicDiaryControllerTest {
     PublicDiary publicDiary2 = mock(PublicDiary.class);
     response.addPublicDiary(publicDiary1);
     response.addPublicDiary(publicDiary2);
-    when(publicDiaryService.getPublicDiaryPagination(any(TodakUser.class), eq(publicDiaryId)))
+    when(publicDiaryService.getPublicDiaryPagination(anyLong(), eq(publicDiaryId)))
         .thenReturn(response);
 
     mockMvc
@@ -165,8 +165,7 @@ public class PublicDiaryControllerTest {
   @WithMockTodakUser
   void getPublicDiaryPagination_Success_DefaultAfterParameter() throws Exception {
     PublicDiaryPaginationResponse response = new PublicDiaryPaginationResponse();
-    when(publicDiaryService.getPublicDiaryPagination(any(TodakUser.class), eq(0L)))
-        .thenReturn(response);
+    when(publicDiaryService.getPublicDiaryPagination(anyLong(), eq(0L))).thenReturn(response);
 
     mockMvc
         .perform(get("/api/v1/diary/public").contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
@@ -75,7 +75,7 @@ public class MySharedDiaryServiceTest {
         .thenReturn(previews);
 
     MySharedDiaryPaginationResponse response =
-        mySharedDiaryService.getPagination(mockUser, publicDiaryId);
+        mySharedDiaryService.getPagination(mockUser.getId(), publicDiaryId);
 
     assertThat(response).as("페이지네이션 응답이 null이 아니어야 합니다").isNotNull();
     assertThat(response.sharedDiaries()).as("페이지네이션 응답의 미리보기 목록은 1개의 항목을 포함해야 합니다").hasSize(1);
@@ -97,7 +97,8 @@ public class MySharedDiaryServiceTest {
             eq(memberId), eq(diaryId + 1), any(PageRequest.class)))
         .thenReturn(previews);
 
-    MySharedDiaryPaginationResponse response = mySharedDiaryService.getPagination(mockUser, 0L);
+    MySharedDiaryPaginationResponse response =
+        mySharedDiaryService.getPagination(mockUser.getId(), 0L);
 
     assertThat(response).as("publicDiaryId가 0일 때의 페이지네이션 응답이 null이 아니어야 합니다").isNotNull();
     assertThat(response.sharedDiaries())
@@ -110,11 +111,12 @@ public class MySharedDiaryServiceTest {
   @DisplayName("페이지네이션 요청시 더 이상 공개된 일기가 없을 때 빈 객체 반환")
   void getPagination_ThrowsException_WhenNoDiaryFound() {
     when(mySharedDiaryRepository.findLatestId(memberId)).thenReturn(Optional.empty());
-    MySharedDiaryPaginationResponse response = mySharedDiaryService.getPagination(mockUser, 0L);
+    MySharedDiaryPaginationResponse response =
+        mySharedDiaryService.getPagination(mockUser.getId(), 0L);
     assertThat(response.sharedDiaries().size()).as("공개된 일기가 없을 때 빈 객체가 반환 되어야 합니다.").isEqualTo(0);
     assertThat(response.isEnd()).as("공개된 일기가 없을 때 isEnd 조건이 true이어야합니다.").isTrue();
 
-    response = mySharedDiaryService.getPagination(mockUser, 999999L);
+    response = mySharedDiaryService.getPagination(mockUser.getId(), 999999L);
     assertThat(response.sharedDiaries().size()).as("공개된 일기가 없을 때 빈 객체가 반환 되어야 합니다.").isEqualTo(0);
     assertThat(response.isEnd()).as("공개된 일기가 없을 때 isEnd 조건이 true이어야합니다.").isTrue();
 
@@ -144,7 +146,7 @@ public class MySharedDiaryServiceTest {
         .thenReturn(List.of(preSigned_webtoonUrl));
     when(s3FileStorageService.preSignedBgmUrlFrom(anyString())).thenReturn(preSigned_bgmUrl);
 
-    MySharedDiaryResponse response = mySharedDiaryService.getDiary(mockUser, requestDate);
+    MySharedDiaryResponse response = mySharedDiaryService.getDiary(mockUser.getId(), requestDate);
 
     assertThat(response).as("조회된 응답이 null이 아니어야 합니다").isNotNull();
 
@@ -167,7 +169,7 @@ public class MySharedDiaryServiceTest {
         .thenReturn(Optional.empty());
 
     // When & Then
-    assertThatThrownBy(() -> mySharedDiaryService.getDiary(mockUser, requestDate))
+    assertThatThrownBy(() -> mySharedDiaryService.getDiary(mockUser.getId(), requestDate))
         .as("존재하지 않는 날짜의 일기 조회시 PublicDiaryNotFoundException이 발생해야 합니다")
         .isInstanceOf(PublicDiaryNotFoundException.class);
   }

--- a/src/test/java/com/heartsave/todaktodak_api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/member/controller/MemberControllerTest.java
@@ -65,7 +65,7 @@ final class MemberControllerTest {
     // when
     doReturn(response)
         .when(memberService)
-        .updateNickname(any(TodakUser.class), any(NicknameUpdateRequest.class));
+        .updateNickname(anyLong(), any(NicknameUpdateRequest.class));
 
     // then
     mockMvc
@@ -76,11 +76,11 @@ final class MemberControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.nickname").value(NEW_NICKNAME))
         .andReturn();
-    verify(memberService, times(1))
-        .updateNickname(any(TodakUser.class), any(NicknameUpdateRequest.class));
+    verify(memberService, times(1)).updateNickname(anyLong(), any(NicknameUpdateRequest.class));
   }
 
   @ParameterizedTest
+  @WithMockTodakUser
   @DisplayName("닉네임 변경 요청 실패 - 유효하지 않은 닉네임")
   @ValueSource(strings = {"", " ", INVALID_NICKNAME_OVER_LENGTH})
   void updateNickname_fail_400Test(String invalidNickname) throws Exception {
@@ -93,8 +93,7 @@ final class MemberControllerTest {
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.title").value("VALIDATION_ERROR"));
 
-    verify(memberService, never())
-        .updateNickname(any(TodakUser.class), any(NicknameUpdateRequest.class));
+    verify(memberService, never()).updateNickname(anyLong(), any(NicknameUpdateRequest.class));
   }
 
   @Test
@@ -110,7 +109,7 @@ final class MemberControllerTest {
     // when
     doThrow(new MemberNotFoundException(MemberErrorSpec.NOT_FOUND, NON_EXISTED_ID))
         .when(memberService)
-        .updateNickname(any(TodakUser.class), any(NicknameUpdateRequest.class));
+        .updateNickname(anyLong(), any(NicknameUpdateRequest.class));
 
     // then
     mockMvc
@@ -118,8 +117,7 @@ final class MemberControllerTest {
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.title").value(MemberErrorSpec.NOT_FOUND.name()));
 
-    verify(memberService, times(1))
-        .updateNickname(any(TodakUser.class), any(NicknameUpdateRequest.class));
+    verify(memberService, times(1)).updateNickname(anyLong(), any(NicknameUpdateRequest.class));
   }
 
   @Test
@@ -135,7 +133,7 @@ final class MemberControllerTest {
             .build();
 
     // when
-    doReturn(response).when(memberService).getMemberProfileById(any(TodakUser.class));
+    doReturn(response).when(memberService).getMemberProfile(anyLong());
 
     // then
     mockMvc
@@ -145,7 +143,7 @@ final class MemberControllerTest {
         .andExpect(jsonPath("$.email").value("test@example.com"))
         .andExpect(jsonPath("$.characterImageUrl").value("presigned-url"));
 
-    verify(memberService, times(1)).getMemberProfileById(any(TodakUser.class));
+    verify(memberService, times(1)).getMemberProfile(anyLong());
   }
 
   @Test
@@ -159,7 +157,7 @@ final class MemberControllerTest {
     // when
     doThrow(new MemberNotFoundException(MemberErrorSpec.NOT_FOUND, mockUser.getId()))
         .when(memberService)
-        .getMemberProfileById(any(TodakUser.class));
+        .getMemberProfile(anyLong());
 
     // then
     mockMvc
@@ -167,7 +165,7 @@ final class MemberControllerTest {
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.title").value(MemberErrorSpec.NOT_FOUND.name()));
 
-    verify(memberService, times(1)).getMemberProfileById(any(TodakUser.class));
+    verify(memberService, times(1)).getMemberProfile(anyLong());
   }
 
   @Test
@@ -175,14 +173,11 @@ final class MemberControllerTest {
   @WithMockTodakUser
   void deactivateMember_success_204Test() throws Exception {
     // when
-    doNothing()
-        .when(memberService)
-        .deactivate(any(HttpServletResponse.class), any(TodakUser.class));
+    doNothing().when(memberService).deactivate(any(HttpServletResponse.class), anyLong());
 
     // then
     mockMvc.perform(post("/api/v1/member/deactivate")).andExpect(status().isNoContent());
-    verify(memberService, times(1))
-        .deactivate(any(HttpServletResponse.class), any(TodakUser.class));
+    verify(memberService, times(1)).deactivate(any(HttpServletResponse.class), anyLong());
   }
 
   @Test
@@ -196,14 +191,13 @@ final class MemberControllerTest {
     // when
     doThrow(new MemberNotFoundException(MemberErrorSpec.NOT_FOUND, mockUser.getId()))
         .when(memberService)
-        .deactivate(any(HttpServletResponse.class), any(TodakUser.class));
+        .deactivate(any(HttpServletResponse.class), anyLong());
 
     // then
     mockMvc
         .perform(post("/api/v1/member/deactivate"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.title").value(MemberErrorSpec.NOT_FOUND.name()));
-    verify(memberService, times(1))
-        .deactivate(any(HttpServletResponse.class), any(TodakUser.class));
+    verify(memberService, times(1)).deactivate(any(HttpServletResponse.class), anyLong());
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/member/service/MemberServiceTest.java
@@ -68,7 +68,7 @@ final class MemberServiceTest {
     when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
 
     // when
-    NicknameUpdateResponse response = memberService.updateNickname(principal, request);
+    NicknameUpdateResponse response = memberService.updateNickname(principal.getId(), request);
 
     // then
     assertThat(response.nickname()).isEqualTo(newNickname);
@@ -82,7 +82,7 @@ final class MemberServiceTest {
         .thenReturn(Optional.of(memberProfileProjection));
 
     // when
-    MemberProfileResponse response = memberService.getMemberProfileById(principal);
+    MemberProfileResponse response = memberService.getMemberProfile(principal.getId());
 
     // then
     assertThat(response.nickname()).isEqualTo(member.getNickname());
@@ -97,7 +97,7 @@ final class MemberServiceTest {
     when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
 
     // when
-    memberService.deactivate(response, principal);
+    memberService.deactivate(response, principal.getId());
 
     // then
     verify(memberRepository).findById(principal.getId());
@@ -113,7 +113,7 @@ final class MemberServiceTest {
 
     // when
     assertThrows(
-        MemberNotFoundException.class, () -> memberService.deactivate(response, principal));
+        MemberNotFoundException.class, () -> memberService.deactivate(response, principal.getId()));
 
     // then
     verify(memberRepository).findById(principal.getId());


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항
대부분의 Controller와 Service에서는 인증 객체의 ```getId()``` 메서드를 사용하기 때문에,
반복적인 코드 작성을 줄이고자 ```@TodakUserId``` 에노테이션을 만들었습니다.

### 기존
- Controller에 ```@AuthenticationPrincipal```을 사용하여 인증 객체를 가져와 활용합니다.

### 변경
- Controller에 ```@TodakUserId```를 사용하면, SecurityContextHolder 에서 인증 객체 id를 가져옵니다.
- MemberService의 경우 메서드 시그치너가 동일한 경우가 있어, 메서드 이름을 수정하였습니다.
- ```getMemberProfileById -> getMemberProfile```
- ```@TodakUserId ``` 에노테이션은 ```Diary, PublicDiary, MySharedDiary, Member, Character``` Controller에 적용하였습니다.

### 적용 방법
- ```HandlerMethodArgumentResolver``` 를 상속 받아 ```TodakUserIdResolver``` 를 만들었습니다.
- ```TodakUserIdResolver```는 SecurityContextHolder에서 인증 객체를 꺼내 id를 반환합니다.
- Resolver를 등록하기 위해 ```WebConfig```에서 Resolver 추가 메서드를 작성하였습니다.
- ```@TodakUserId``` 에노테이션은 ```auth/annotation``` 패키지에 있습니다.


## 리뷰 받고 싶은 내용

- id를 꺼내는 과정 중심으로 확인 부탁드립니다.

## 테스트 및 결과
- 테스트 코드에도 인증 객체가 아닌 id를 입력하는 것 으로 수정하였습니다.


## 관련 스크린샷 및 참고자료 (Optional)

close #103 