### PR TITLE
refactor: 웹 클라이언트 날짜 타입 변경 TODAK-246

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientBgmRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientBgmRequest.java
@@ -1,6 +1,7 @@
 package com.heartsave.todaktodak_api.ai.client.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.heartsave.todaktodak_api.common.converter.InstantConverter;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -19,7 +20,7 @@ public class ClientBgmRequest {
 
   private ClientBgmRequest(DiaryEntity diary, MemberEntity member) {
     this.memberId = member.getId();
-    this.date = diary.getDiaryCreatedTime().toLocalDate();
+    this.date = InstantConverter.toLocalDate(diary.getDiaryCreatedTime());
     this.content = diary.getContent();
     this.emotion = diary.getEmotion();
   }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
@@ -1,6 +1,7 @@
 package com.heartsave.todaktodak_api.ai.client.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.heartsave.todaktodak_api.common.converter.InstantConverter;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import java.time.LocalDate;
@@ -20,7 +21,7 @@ public class ClientWebtoonRequest {
 
   private ClientWebtoonRequest(DiaryEntity diary, MemberEntity member) {
     this.memberId = String.valueOf(member.getId());
-    this.date = diary.getDiaryCreatedTime().toLocalDate();
+    this.date = InstantConverter.toLocalDate(diary.getDiaryCreatedTime());
     this.content = diary.getContent();
     this.characterInfo = member.getCharacterInfo();
     this.seedNum = member.getCharacterSeed();

--- a/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
@@ -8,4 +8,8 @@ public final class CoreConstant {
   public static class URL {
     public static final String DEFAULT_URL = "";
   }
+
+  public static class TIME_FORMAT {
+    public static final String ISO_DATETIME_WITH_MILLISECONDS = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/converter/InstantConverter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/converter/InstantConverter.java
@@ -1,0 +1,37 @@
+package com.heartsave.todaktodak_api.common.converter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+public class InstantConverter {
+  public static LocalDate toLocalDate(Instant instant) {
+    return instant.atZone(ZoneId.of("UTC")).toLocalDate();
+  }
+
+  public static LocalDateTime toLocalDateTime(Instant instant) {
+    return instant.atZone(ZoneId.of("UTC")).toLocalDateTime();
+  }
+
+  public static Instant toMonthStartDateTime(Instant yearMonth) {
+    return yearMonth
+        .atZone(ZoneOffset.UTC)
+        .withDayOfMonth(1)
+        .withHour(0)
+        .withMinute(0)
+        .withSecond(0)
+        .withNano(0)
+        .toInstant();
+  }
+
+  public static Instant toMonthEndDateTime(Instant yearMonth) {
+    return yearMonth
+        .atZone(ZoneOffset.UTC)
+        .withDayOfMonth(1)
+        .plusMonths(1)
+        .minusNanos(1)
+        .toInstant();
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/entity/BaseEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/entity/BaseEntity.java
@@ -3,15 +3,13 @@ package com.heartsave.todaktodak_api.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 @Getter
 @EntityListeners(AuditingEntityListener.class)
@@ -20,8 +18,7 @@ public class BaseEntity {
 
   @CreatedDate
   @Column(name = "created_time", updatable = false, columnDefinition = "TIMESTAMP(3)")
-  @DateTimeFormat(iso = ISO.DATE_TIME)
-  private LocalDateTime createdTime;
+  private Instant createdTime;
 
   @CreatedBy
   @Column(name = "created_by")
@@ -29,8 +26,7 @@ public class BaseEntity {
 
   @LastModifiedDate
   @Column(name = "updated_time", columnDefinition = "TIMESTAMP(3)")
-  @DateTimeFormat(iso = ISO.DATE_TIME)
-  private LocalDateTime updatedTime;
+  private Instant updatedTime;
 
   @LastModifiedBy
   @Column(name = "updated_By")

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -15,11 +15,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
-import java.time.LocalDate;
-import java.time.YearMonth;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -90,10 +88,9 @@ public class DiaryController {
               description = "조회할 연월",
               example = "2024-10",
               required = true,
-              schema = @Schema(type = "string", format = "yyyy-MM"))
+              schema = @Schema(type = "string"))
           @RequestParam("yearMonth")
-          @DateTimeFormat(pattern = "yyyy-MM")
-          YearMonth yearMonth) {
+          Instant yearMonth) {
     return ResponseEntity.status(HttpStatus.OK).body(diaryService.getIndex(memberId, yearMonth));
   }
 
@@ -112,11 +109,11 @@ public class DiaryController {
               description = "조회할 일기의 날짜",
               example = "2024-10-26",
               required = true,
-              schema = @Schema(type = "string", format = "yyyy-MM-dd"))
+              schema = @Schema(type = "string", format = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
           @Valid
           @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.")
           @RequestParam("date")
-          LocalDate requestDate) {
+          Instant requestDate) {
     return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(memberId, requestDate));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -68,12 +68,12 @@ public class MySharedDiaryController {
               name = "date",
               description = "조회할 일기 날짜",
               example = "2024-11-04",
-              schema = @Schema(type = "string", format = "date"))
+              schema = @Schema(type = "string", format = "Instant"))
           @Valid
           @PastOrPresent
           @RequestParam("date")
-          LocalDateTime requestDate) {
+          Instant requestDateTime) {
     return ResponseEntity.status(HttpStatus.OK)
-        .body(mySharedDiaryService.getDiary(memberId, requestDate.toLocalDate()));
+        .body(mySharedDiaryService.getDiary(memberId, requestDateTime));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/PublicDiary.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/PublicDiary.java
@@ -1,10 +1,12 @@
 package com.heartsave.todaktodak_api.diary.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.heartsave.todaktodak_api.common.constant.CoreConstant.TIME_FORMAT;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import com.heartsave.todaktodak_api.diary.entity.projection.PublicDiaryContentOnlyProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import lombok.Getter;
 
@@ -37,7 +39,8 @@ public class PublicDiary {
   private final String bgmUrl;
 
   @Schema(description = "일기 작성 날짜", example = "2024-10-26", type = "string", format = "date")
-  private final LocalDate createdDate;
+  @JsonFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS, timezone = "UTC")
+  private final Instant createdDate;
 
   @Schema(description = "일기에 대한 반응 수 정보")
   private final DiaryReactionCountProjection reactionCount;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/DiaryWriteRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/DiaryWriteRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -27,7 +27,7 @@ public class DiaryWriteRequest {
   @PastOrPresent(message = "Diary Writing Date is Future")
   @NotNull
   @JsonProperty("date")
-  private LocalDateTime dateTime;
+  private Instant dateTime;
 
   @Schema(description = "일기에 기록된 감정", example = "happy", required = true)
   @NotNull(message = "DiaryEmotion is Null")

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryResponse.java
@@ -1,8 +1,10 @@
 package com.heartsave.todaktodak_api.diary.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.heartsave.todaktodak_api.common.constant.CoreConstant.TIME_FORMAT;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,5 +36,6 @@ public class DiaryResponse {
   private String aiComment;
 
   @Schema(description = "일기 작성 날짜", example = "2024-10-26", type = "string", format = "date")
-  private LocalDate date;
+  @JsonFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS, timezone = "UTC")
+  private Instant dateTime;
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/MySharedDiaryResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/MySharedDiaryResponse.java
@@ -1,10 +1,12 @@
 package com.heartsave.todaktodak_api.diary.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.heartsave.todaktodak_api.common.constant.CoreConstant.TIME_FORMAT;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryReactionCountProjection;
 import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryContentOnlyProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -35,8 +37,13 @@ public class MySharedDiaryResponse {
   @Schema(description = "내가 한 리액션 목록", example = "[like, empathize]")
   private final List<DiaryReactionType> myReaction;
 
-  @Schema(description = "일기 작성 날짜", example = "2024-01-01", type = "string", format = "date")
-  private final LocalDate diaryCreatedDate;
+  @Schema(
+      description = "일기 작성 날짜",
+      example = "2024-01-01'T'00:11:10.752'Z'",
+      type = "string",
+      format = "date")
+  @JsonFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS, timezone = "UTC")
+  private final Instant diaryCreatedDate;
 
   private MySharedDiaryResponse(
       MySharedDiaryContentOnlyProjection content,

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
@@ -23,7 +23,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -31,8 +31,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 @Entity
 @Getter
@@ -78,8 +76,7 @@ public class DiaryEntity extends BaseEntity {
       nullable = false,
       updatable = false,
       columnDefinition = "TIMESTAMP(3)")
-  @DateTimeFormat(iso = ISO.DATE_TIME)
-  private LocalDateTime diaryCreatedTime;
+  private Instant diaryCreatedTime;
 
   @OneToMany(
       fetch = FetchType.LAZY,

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryIndexProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryIndexProjection.java
@@ -2,8 +2,9 @@ package com.heartsave.todaktodak_api.diary.entity.projection;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.heartsave.todaktodak_api.common.constant.CoreConstant.TIME_FORMAT;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Schema(description = "연월 일기 작성 현황 API 응답 데이터")
 public interface DiaryIndexProjection {
@@ -12,6 +13,6 @@ public interface DiaryIndexProjection {
   Long getId();
 
   @JsonProperty("date")
-  @JsonFormat(pattern = "yyyy-MM-dd")
-  LocalDateTime getDiaryCreatedTime();
+  @JsonFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS, timezone = "UTC")
+  Instant getDiaryCreatedTime();
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/MySharedDiaryContentOnlyProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/MySharedDiaryContentOnlyProjection.java
@@ -1,7 +1,9 @@
 package com.heartsave.todaktodak_api.diary.entity.projection;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.heartsave.todaktodak_api.common.constant.CoreConstant.TIME_FORMAT;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import lombok.Getter;
 
@@ -27,7 +29,8 @@ public class MySharedDiaryContentOnlyProjection {
   private String bgmUrl;
 
   @Schema(description = "공개된 일기 작성 날짜", example = "2024-01-01", type = "string", format = "date")
-  private final LocalDate diaryCreatedDate;
+  @JsonFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS)
+  private final Instant diaryCreatedDate;
 
   public MySharedDiaryContentOnlyProjection(
       Long publicDiaryId,
@@ -35,7 +38,7 @@ public class MySharedDiaryContentOnlyProjection {
       String publicContent,
       String webtoonImageUrl,
       String bgmUrl,
-      LocalDate diaryCreatedDate) {
+      Instant diaryCreatedDate) {
     this.publicDiaryId = publicDiaryId;
     this.diaryId = diaryId;
     this.publicContent = publicContent;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/MySharedDiaryPreviewProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/MySharedDiaryPreviewProjection.java
@@ -1,7 +1,9 @@
 package com.heartsave.todaktodak_api.diary.entity.projection;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.heartsave.todaktodak_api.common.constant.CoreConstant.TIME_FORMAT;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -17,7 +19,8 @@ public class MySharedDiaryPreviewProjection {
   private String webtoonImageUrl;
 
   @Schema(description = "일기 작성 날짜", example = "2024-01-01", type = "string", format = "date")
-  private final LocalDate createdDate;
+  @JsonFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS, timezone = "UTC")
+  private final Instant createdDate;
 
   public void replaceWebtoonImageUrl(String webtoonImageUrl) {
     this.webtoonImageUrl = webtoonImageUrl;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/PublicDiaryContentOnlyProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/PublicDiaryContentOnlyProjection.java
@@ -1,9 +1,11 @@
 package com.heartsave.todaktodak_api.diary.entity.projection;
 
+import com.heartsave.todaktodak_api.common.constant.CoreConstant.TIME_FORMAT;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @Schema(description = "공개 일기 조회 프로젝션")
@@ -33,7 +35,8 @@ public class PublicDiaryContentOnlyProjection {
   private String bgmUrl;
 
   @Schema(description = "일기 작성 날짜", example = "2024-10-26", type = "string", format = "date")
-  private final LocalDate date;
+  @DateTimeFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS)
+  private final Instant date;
 
   public PublicDiaryContentOnlyProjection(
       Long publicDiaryId,
@@ -43,7 +46,7 @@ public class PublicDiaryContentOnlyProjection {
       String publicContent,
       String webtoonImageUrl,
       String bgmUrl,
-      LocalDate date) {
+      Instant date) {
     this.publicDiaryId = publicDiaryId;
     this.diaryId = diaryId;
     this.characterImageUrl = characterImageUrls;

--- a/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryException.java
@@ -3,7 +3,7 @@ package com.heartsave.todaktodak_api.diary.exception;
 import com.heartsave.todaktodak_api.common.exception.BaseException;
 import com.heartsave.todaktodak_api.common.exception.ErrorFieldBuilder;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
-import java.time.LocalDate;
+import java.time.Instant;
 import lombok.Getter;
 
 @Getter
@@ -19,7 +19,7 @@ public abstract class DiaryException extends BaseException {
     super(errorSpec, ErrorFieldBuilder.builder().add("memberId", memberId).build());
   }
 
-  protected DiaryException(DiaryErrorSpec errorSpec, Long memberId, LocalDate diaryDate) {
+  protected DiaryException(DiaryErrorSpec errorSpec, Long memberId, Instant diaryDate) {
     super(
         errorSpec,
         ErrorFieldBuilder.builder().add("memberId", memberId).add("diaryDate", diaryDate).build());

--- a/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryNotFoundException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/exception/DiaryNotFoundException.java
@@ -1,11 +1,11 @@
 package com.heartsave.todaktodak_api.diary.exception;
 
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
-import java.time.LocalDate;
+import java.time.Instant;
 
 public class DiaryNotFoundException extends DiaryException {
 
-  public DiaryNotFoundException(DiaryErrorSpec errorSpec, Long memberId, LocalDate diaryDate) {
+  public DiaryNotFoundException(DiaryErrorSpec errorSpec, Long memberId, Instant diaryDate) {
     super(errorSpec, memberId, diaryDate);
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/diary/exception/PublicDiaryNotFoundException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/exception/PublicDiaryNotFoundException.java
@@ -2,7 +2,7 @@ package com.heartsave.todaktodak_api.diary.exception;
 
 import com.heartsave.todaktodak_api.common.exception.ErrorFieldBuilder;
 import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
-import java.time.LocalDate;
+import java.time.Instant;
 
 public class PublicDiaryNotFoundException extends PublicDiaryException {
 
@@ -10,7 +10,7 @@ public class PublicDiaryNotFoundException extends PublicDiaryException {
     super(errorSpec, ErrorFieldBuilder.builder().add("publicDiaryId", publicDiaryId).build());
   }
 
-  public PublicDiaryNotFoundException(ErrorSpec errorSpec, LocalDate publicDiaryCreatedDate) {
+  public PublicDiaryNotFoundException(ErrorSpec errorSpec, Instant publicDiaryCreatedDate) {
     super(
         errorSpec,
         ErrorFieldBuilder.builder().add("publicDiaryCreatedDate", publicDiaryCreatedDate).build());

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -2,8 +2,8 @@ package com.heartsave.todaktodak_api.diary.repository;
 
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,9 +17,8 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
       value =
           "SELECT CASE WHEN COUNT(d) > 0 THEN true ELSE false END FROM DiaryEntity d "
               + "WHERE d.memberEntity.id = :memberId "
-              + "AND CAST(d.diaryCreatedTime AS date) = CAST(:diaryDate AS date)")
-  boolean existsByDate(
-      @Param("memberId") Long memberId, @Param("diaryDate") LocalDateTime diaryDate);
+              + "AND  CAST(d.diaryCreatedTime AS LocalDate)  = :diaryDate")
+  boolean existsByDate(@Param("memberId") Long memberId, @Param("diaryDate") LocalDate diaryDate);
 
   @Modifying
   @Query(
@@ -31,8 +30,8 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
           "SELECT d.id as id, d.diaryCreatedTime as diaryCreatedTime FROM DiaryEntity d WHERE d.memberEntity.id = :memberId AND d.diaryCreatedTime BETWEEN :startDateTime AND :endDateTime ORDER BY d.diaryCreatedTime ASC")
   Optional<List<DiaryIndexProjection>> findIndexesByMemberIdAndDateTimes(
       @Param("memberId") Long memberId,
-      @Param("startDateTime") LocalDateTime startDateTime,
-      @Param("endDateTime") LocalDateTime endDateTime);
+      @Param("startDateTime") Instant startDateTime,
+      @Param("endDateTime") Instant endDateTime);
 
   @Query(
       value =

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
@@ -29,11 +29,11 @@ public interface MySharedDiaryRepository extends JpaRepository<PublicDiaryEntity
                        new com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreviewProjection(
                        pd.id,
                        d.webtoonImageUrl,
-                       CAST (pd.createdTime AS Localdate)
+                       pd.createdTime
                        )
                       FROM PublicDiaryEntity pd JOIN pd.diaryEntity d
                       WHERE pd.memberEntity.id = :memberId AND pd.id < :publicDiaryId
-                      ORDER BY pd.id DESC
+                      ORDER BY pd.createdTime DESC, pd.id DESC
           """)
   List<MySharedDiaryPreviewProjection> findNextPreviews(
       @Param("memberId") Long memberId,
@@ -48,7 +48,7 @@ public interface MySharedDiaryRepository extends JpaRepository<PublicDiaryEntity
                 pd.publicContent,
                 d.webtoonImageUrl,
                 d.bgmUrl,
-                CAST(d.diaryCreatedTime as LocalDate)
+                d.diaryCreatedTime
             )
             FROM PublicDiaryEntity pd
             JOIN pd.diaryEntity d

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/PublicDiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/PublicDiaryRepository.java
@@ -24,13 +24,13 @@ public interface PublicDiaryRepository extends JpaRepository<PublicDiaryEntity, 
             pd.publicContent,
             d.webtoonImageUrl,
             d.bgmUrl,
-            CAST(d.diaryCreatedTime as LocalDate)
+            d.diaryCreatedTime
         )
         FROM PublicDiaryEntity pd
         JOIN pd.diaryEntity d
         JOIN pd.memberEntity m
         WHERE pd.id < :publicDiaryId
-        ORDER BY pd.id DESC
+        ORDER BY pd.createdTime DESC, pd.id DESC
         """)
   List<PublicDiaryContentOnlyProjection> findNextContentOnlyById(
       @Param("publicDiaryId") Long publicDiaryId, Pageable pageable);

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -4,6 +4,7 @@ import static com.heartsave.todaktodak_api.common.constant.CoreConstant.URL.DEFA
 
 import com.heartsave.todaktodak_api.ai.client.dto.response.AiDiaryContentResponse;
 import com.heartsave.todaktodak_api.ai.client.service.AiClientService;
+import com.heartsave.todaktodak_api.common.converter.InstantConverter;
 import com.heartsave.todaktodak_api.common.exception.errorspec.DiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
@@ -20,10 +21,7 @@ import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.YearMonth;
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,9 +41,10 @@ public class DiaryService {
 
   public DiaryWriteResponse write(Long memberId, DiaryWriteRequest request) {
     DiaryEntity diary = createDiaryEntity(memberId, request);
-    LocalDateTime diaryCreatedDate = diary.getDiaryCreatedTime();
+    Instant diaryCreatedTime = diary.getDiaryCreatedTime();
 
-    if (diaryRepository.existsByDate(memberId, diaryCreatedDate)) {
+    if (diaryRepository.existsByDate(
+        memberId, InstantConverter.toLocalDate(diary.getDiaryCreatedTime()))) {
       throw new DiaryDailyWritingLimitExceedException(
           DiaryErrorSpec.DAILY_WRITING_LIMIT_EXCEED, memberId);
     }
@@ -71,23 +70,25 @@ public class DiaryService {
     return;
   }
 
-  public DiaryIndexResponse getIndex(Long memberId, YearMonth yearMonth) {
-    LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
-    LocalDateTime endDateTime = yearMonth.atEndOfMonth().atTime(LocalTime.MAX);
+  public DiaryIndexResponse getIndex(Long memberId, Instant yearMonth) {
+    Instant startDateTime = InstantConverter.toMonthStartDateTime(yearMonth);
+    Instant endDateTime = InstantConverter.toMonthEndDateTime(yearMonth);
+
     log.info("해당 연월에 작성한 일기를 정보를 요청합니다.");
     List<DiaryIndexProjection> indexes =
         diaryRepository
             .findIndexesByMemberIdAndDateTimes(memberId, startDateTime, endDateTime)
             .orElseGet(List::of);
+
     log.info("해당 연월에 작성한 일기를 정보를 성공적으로 가져왔습니다.");
     return DiaryIndexResponse.builder().diaryIndexes(indexes).build();
   }
 
-  public DiaryResponse getDiary(Long memberId, LocalDate requestDate) {
+  public DiaryResponse getDiary(Long memberId, Instant requestDate) {
     log.info("사용자의 나의 일기 정보를 요청합니다.");
     DiaryEntity diary =
         diaryRepository
-            .findByMemberIdAndDate(memberId, requestDate)
+            .findByMemberIdAndDate(memberId, InstantConverter.toLocalDate(requestDate))
             .orElseThrow(
                 () ->
                     new DiaryNotFoundException(
@@ -102,7 +103,7 @@ public class DiaryService {
             s3FileStorageService.preSignedWebtoonUrlFrom(List.of(diary.getWebtoonImageUrl())))
         .bgmUrl(s3FileStorageService.preSignedBgmUrlFrom(diary.getBgmUrl()))
         .aiComment(diary.getAiComment())
-        .date(diary.getDiaryCreatedTime().toLocalDate())
+        .dateTime(diary.getDiaryCreatedTime())
         .build();
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
@@ -1,5 +1,6 @@
 package com.heartsave.todaktodak_api.diary.service;
 
+import com.heartsave.todaktodak_api.common.converter.InstantConverter;
 import com.heartsave.todaktodak_api.common.exception.errorspec.PublicDiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
@@ -11,7 +12,7 @@ import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreview
 import com.heartsave.todaktodak_api.diary.exception.PublicDiaryNotFoundException;
 import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.MySharedDiaryRepository;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,9 +56,9 @@ public class MySharedDiaryService {
     }
   }
 
-  public MySharedDiaryResponse getDiary(Long memberId, LocalDate requestDate) {
+  public MySharedDiaryResponse getDiary(Long memberId, Instant requestInstant) {
     log.info("나의 공개된 일기 상세 정보를 요청합니다.");
-    MySharedDiaryContentOnlyProjection contentOnly = fetchContentOnly(requestDate, memberId);
+    MySharedDiaryContentOnlyProjection contentOnly = fetchContentOnly(requestInstant, memberId);
     replaceWithPreSignedUrls(contentOnly);
 
     DiaryReactionCountProjection reactionCount =
@@ -76,15 +77,16 @@ public class MySharedDiaryService {
   }
 
   private MySharedDiaryContentOnlyProjection fetchContentOnly(
-      LocalDate requestDate, Long memberId) {
+      Instant requestDateTime, Long memberId) {
     log.info("나의 공개된 일기 content only 를 요청합니다.");
     MySharedDiaryContentOnlyProjection contentOnly =
         mySharedDiaryRepository
-            .findContentOnly(memberId, requestDate)
+            .findContentOnly(memberId, InstantConverter.toLocalDate(requestDateTime))
             .orElseThrow(
                 () ->
                     new PublicDiaryNotFoundException(
-                        PublicDiaryErrorSpec.PUBLIC_DIARY_NOT_FOUND, requestDate));
+                        PublicDiaryErrorSpec.PUBLIC_DIARY_NOT_FOUND, requestDateTime));
+
     return contentOnly;
   }
 }

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
@@ -14,6 +14,7 @@ import com.heartsave.todaktodak_api.ai.webhook.service.AiDiaryService;
 import com.heartsave.todaktodak_api.ai.webhook.service.AiWebhookCharacterService;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.config.WebConfig;
+import com.heartsave.todaktodak_api.common.converter.InstantConverter;
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -69,7 +70,9 @@ class AiWebhookControllerTest {
     void saveWebtoon_ValidRequest_Returns204() throws Exception {
       WebhookWebtoonCompletionRequest request =
           new WebhookWebtoonCompletionRequest(
-              member.getId(), diary.getDiaryCreatedTime().toLocalDate(), TEST_WEBTOON_URL);
+              member.getId(),
+              InstantConverter.toLocalDate(diary.getDiaryCreatedTime()),
+              TEST_WEBTOON_URL);
 
       doNothing().when(aiDiaryService).saveWebtoon(any(WebhookWebtoonCompletionRequest.class));
 
@@ -88,7 +91,7 @@ class AiWebhookControllerTest {
     void saveWebtoon_InvalidRequest_Returns400() throws Exception {
       WebhookWebtoonCompletionRequest request =
           new WebhookWebtoonCompletionRequest(
-              null, diary.getDiaryCreatedTime().toLocalDate(), TEST_WEBTOON_URL);
+              null, InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), TEST_WEBTOON_URL);
 
       mockMvc
           .perform(
@@ -111,7 +114,9 @@ class AiWebhookControllerTest {
     void saveBgm_ValidRequest_Returns204() throws Exception {
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              member.getId(), diary.getDiaryCreatedTime().toLocalDate(), TEST_BGM_URL);
+              member.getId(),
+              InstantConverter.toLocalDate(diary.getDiaryCreatedTime()),
+              TEST_BGM_URL);
 
       doNothing().when(aiDiaryService).saveBgm(any(WebhookBgmCompletionRequest.class));
 
@@ -130,7 +135,7 @@ class AiWebhookControllerTest {
     void saveBgm_InvalidRequest_Returns400() throws Exception {
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              null, diary.getDiaryCreatedTime().toLocalDate(), TEST_BGM_URL);
+              null, InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), TEST_BGM_URL);
 
       mockMvc
           .perform(
@@ -148,7 +153,7 @@ class AiWebhookControllerTest {
     void saveBgm_EmptyBgmUrl_Returns400() throws Exception {
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              member.getId(), diary.getDiaryCreatedTime().toLocalDate(), "");
+              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), "");
 
       mockMvc
           .perform(

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepositoryTest.java
@@ -8,11 +8,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookBgmCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonCompletionRequest;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
+import com.heartsave.todaktodak_api.common.converter.InstantConverter;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +36,7 @@ class AiRepositoryTest {
 
   private MemberEntity member;
   private DiaryEntity diary;
-  private LocalDateTime nowDateTime = LocalDateTime.now();
+  private Instant nowDateTime = Instant.now();
 
   @BeforeEach
   void setUp() {
@@ -58,7 +60,7 @@ class AiRepositoryTest {
       String newUrl = "https://new-url/webtoon.jpg";
       WebhookWebtoonCompletionRequest request =
           new WebhookWebtoonCompletionRequest(
-              member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newUrl);
+              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), newUrl);
 
       aiRepository.updateWebtoonUrl(request, request.webtoonFolderUrl());
 
@@ -91,7 +93,7 @@ class AiRepositoryTest {
       String newBgmUrl = "/music-ai/1/2024/11/06/bgm.mp3";
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newBgmUrl);
+              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), newBgmUrl);
 
       aiRepository.updateBgmUrl(request, request.bgmUrl());
 
@@ -136,7 +138,7 @@ class AiRepositoryTest {
       String newBgmUrl = "https://new-url/target-member-bgm.mp3";
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              member.getId(), diary.getDiaryCreatedTime().toLocalDate(), newBgmUrl);
+              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), newBgmUrl);
 
       aiRepository.updateBgmUrl(request, request.bgmUrl());
 
@@ -157,7 +159,7 @@ class AiRepositoryTest {
     void returnsFalseWhenBothUrlsAreEmpty() {
       Boolean result =
           aiRepository.isContentCompleted(
-              member.getId(), diary.getDiaryCreatedTime().toLocalDate());
+              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()));
 
       assertThat(result).isFalse();
     }
@@ -181,7 +183,7 @@ class AiRepositoryTest {
 
       Boolean result =
           aiRepository.isContentCompleted(
-              member.getId(), diaryWithBgm.getDiaryCreatedTime().toLocalDate());
+              member.getId(), InstantConverter.toLocalDate(nowDateTime));
 
       assertThat(result).isFalse();
     }
@@ -205,7 +207,7 @@ class AiRepositoryTest {
 
       Boolean result =
           aiRepository.isContentCompleted(
-              member.getId(), diaryWithWebtoon.getDiaryCreatedTime().toLocalDate());
+              member.getId(), InstantConverter.toLocalDate(nowDateTime));
 
       assertThat(result).isFalse();
     }
@@ -219,7 +221,8 @@ class AiRepositoryTest {
               .content(DUMMY_STRING_CONTENT)
               .bgmUrl(TEST_BGM_URL)
               .webtoonImageUrl(TEST_WEBTOON_URL)
-              .diaryCreatedTime(LocalDateTime.now().plusDays(1)) // BeforeEach의 diary 날짜 다르게 하기 위해
+              .diaryCreatedTime(
+                  Instant.now().plus(1, ChronoUnit.DAYS)) // BeforeEach의 diary 날짜 다르게 하기 위해
               .emotion(DiaryEmotion.HAPPY)
               .build();
 
@@ -229,7 +232,7 @@ class AiRepositoryTest {
 
       Boolean result =
           aiRepository.isContentCompleted(
-              member.getId(), completedDiary.getDiaryCreatedTime().toLocalDate());
+              member.getId(), InstantConverter.toLocalDate(completedDiary.getDiaryCreatedTime()));
 
       assertThat(result).isTrue();
     }

--- a/src/test/java/com/heartsave/todaktodak_api/common/BaseTestObject.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/BaseTestObject.java
@@ -4,6 +4,7 @@ import com.heartsave.todaktodak_api.common.security.domain.AuthType;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
@@ -63,7 +64,7 @@ public class BaseTestObject {
     return DiaryEntity.builder()
         .id(1L)
         .emotion(DiaryEmotion.HAPPY)
-        .diaryCreatedTime(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        .diaryCreatedTime(Instant.now())
         .content(TEST_DIARY_CONTENT)
         .memberEntity(createMember())
         .webtoonImageUrl(TEST_DEFAULT_WEBTOON_URL)
@@ -76,7 +77,7 @@ public class BaseTestObject {
     return DiaryEntity.builder()
         .id(1L)
         .emotion(DiaryEmotion.HAPPY)
-        .diaryCreatedTime(LocalDateTime.now())
+        .diaryCreatedTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
         .content(TEST_DIARY_CONTENT)
         .memberEntity(member)
         .webtoonImageUrl(TEST_DEFAULT_WEBTOON_URL)
@@ -88,7 +89,7 @@ public class BaseTestObject {
   public static DiaryEntity createDiaryNoIdWithMember(MemberEntity member) {
     return DiaryEntity.builder()
         .emotion(DiaryEmotion.HAPPY)
-        .diaryCreatedTime(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS))
+        .diaryCreatedTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
         .content(TEST_DIARY_CONTENT)
         .memberEntity(member)
         .webtoonImageUrl(TEST_DEFAULT_WEBTOON_URL)
@@ -98,7 +99,7 @@ public class BaseTestObject {
   }
 
   public static DiaryEntity createDiaryNoIdWithMemberAndCreatedDateTime(
-      MemberEntity member, LocalDateTime createdDateTime) {
+      MemberEntity member, Instant createdDateTime) {
     return DiaryEntity.builder()
         .emotion(DiaryEmotion.HAPPY)
         .diaryCreatedTime(createdDateTime)

--- a/src/test/java/com/heartsave/todaktodak_api/diary/common/TestDiaryObjectFactory.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/common/TestDiaryObjectFactory.java
@@ -1,7 +1,9 @@
 package com.heartsave.todaktodak_api.diary.common;
 
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 public class TestDiaryObjectFactory {
@@ -15,8 +17,8 @@ public class TestDiaryObjectFactory {
               }
 
               @Override
-              public LocalDateTime getDiaryCreatedTime() {
-                return LocalDateTime.of(2024, 3, 15, 14, 30);
+              public Instant getDiaryCreatedTime() {
+                return LocalDateTime.of(2024, 3, 15, 14, 30).atZone(ZoneId.of("UTC")).toInstant();
               }
             },
             new DiaryIndexProjection() {
@@ -26,8 +28,8 @@ public class TestDiaryObjectFactory {
               }
 
               @Override
-              public LocalDateTime getDiaryCreatedTime() {
-                return LocalDateTime.of(2024, 3, 20, 16, 45);
+              public Instant getDiaryCreatedTime() {
+                return LocalDateTime.of(2024, 3, 20, 16, 45).atZone(ZoneId.of("UTC")).toInstant();
               }
             });
     return mockIndexes;

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
@@ -24,9 +24,9 @@ import com.heartsave.todaktodak_api.diary.dto.response.DiaryResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryWriteResponse;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
 import com.heartsave.todaktodak_api.diary.service.DiaryService;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -56,7 +56,7 @@ public class DiaryControllerTest {
   void writeDiarySuccess() throws Exception {
     DiaryWriteRequest request =
         new DiaryWriteRequest(
-            LocalDateTime.now(), DiaryEmotion.HAPPY, BaseTestObject.DUMMY_STRING_CONTENT);
+            Instant.now(), DiaryEmotion.HAPPY, BaseTestObject.DUMMY_STRING_CONTENT);
 
     final String AI_COMMENT = "this is test ai comment";
 
@@ -115,14 +115,16 @@ public class DiaryControllerTest {
     List<DiaryIndexProjection> mockIndexes = getTestDiaryIndexProjections_2024_03_Data_Of_2();
     DiaryIndexResponse mockResponse =
         DiaryIndexResponse.builder().diaryIndexes(mockIndexes).build();
+    String yearMonth = "2024-03-01T09:12:30.123Z";
 
     // when
-    when(diaryService.getIndex(anyLong(), any(YearMonth.class))).thenReturn(mockResponse);
+    when(diaryService.getIndex(anyLong(), any(Instant.class))).thenReturn(mockResponse);
 
     // then
-    MvcResult mvcResult =
+    MvcResult mvcResult = null;
+    mvcResult =
         mockMvc
-            .perform(get("/api/v1/diary/my").param("yearMonth", "2024-03"))
+            .perform(get("/api/v1/diary/my").param("yearMonth", yearMonth))
             .andExpect(status().isOk())
             .andDo(print())
             .andReturn();
@@ -145,14 +147,15 @@ public class DiaryControllerTest {
   void getZeroOfDiaryYearMonthSuccess() throws Exception {
     // response
     DiaryIndexResponse mockResponse = new DiaryIndexResponse(new ArrayList<>());
+    String yearMonth = "2024-01-01T00:00:00.010Z";
 
     // when
-    when(diaryService.getIndex(anyLong(), any(YearMonth.class))).thenReturn(mockResponse);
+    when(diaryService.getIndex(anyLong(), any(Instant.class))).thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult =
         mockMvc
-            .perform(get("/api/v1/diary/my").param("yearMonth", "2024-01"))
+            .perform(get("/api/v1/diary/my").param("yearMonth", yearMonth))
             .andExpect(status().isOk())
             .andDo(print())
             .andReturn();
@@ -166,16 +169,16 @@ public class DiaryControllerTest {
   @WithMockTodakUser
   void getDiarySuccess() throws Exception {
     // given
-    LocalDate validDate = LocalDate.now().minusDays(1); // 어제 날짜
+    Instant validDate = Instant.now().minus(1, ChronoUnit.DAYS); // 어제 날짜
     DiaryResponse mockResponse =
         DiaryResponse.builder()
             .content("테스트 일기 내용")
             .emotion(DiaryEmotion.HAPPY)
-            .date(validDate)
+            .dateTime(validDate)
             .build();
 
     // when
-    when(diaryService.getDiary(anyLong(), any(LocalDate.class))).thenReturn(mockResponse);
+    when(diaryService.getDiary(anyLong(), any(Instant.class))).thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult =

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -32,10 +32,12 @@ import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -59,7 +61,7 @@ public class DiaryServiceTest {
   @InjectMocks private DiaryService diaryService;
   private MemberEntity member;
   private DiaryEntity diary;
-  private final LocalDateTime NOW_DATE_TIME = LocalDateTime.now();
+  private final Instant NOW_DATE_TIME = Instant.now();
 
   @BeforeEach
   void allSetup() {
@@ -75,7 +77,7 @@ public class DiaryServiceTest {
     String AI_COMMENT = "this is test ai comment";
 
     when(mockMemberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-    when(mockDiaryRepository.existsByDate(anyLong(), any(LocalDateTime.class))).thenReturn(false);
+    when(mockDiaryRepository.existsByDate(anyLong(), any(LocalDate.class))).thenReturn(false);
     when(mockAiClientService.callDiaryContent(any(DiaryEntity.class)))
         .thenReturn(AiDiaryContentResponse.builder().aiComment("this is test ai comment").build());
 
@@ -89,7 +91,7 @@ public class DiaryServiceTest {
     DiaryWriteRequest request =
         new DiaryWriteRequest(NOW_DATE_TIME, DiaryEmotion.HAPPY, "test diary content");
     when(mockMemberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-    when(mockDiaryRepository.existsByDate(anyLong(), any(LocalDateTime.class))).thenReturn(true);
+    when(mockDiaryRepository.existsByDate(anyLong(), any(LocalDate.class))).thenReturn(true);
 
     DiaryException diaryException =
         assertThrows(
@@ -131,15 +133,21 @@ public class DiaryServiceTest {
   void yearMonthMoreThanOneSuccess() {
     int testYear = 2024;
     int testMonth = 3;
-    LocalDateTime testStart = YearMonth.of(testYear, testMonth).atDay(1).atStartOfDay();
-    LocalDateTime testEnd = YearMonth.of(testYear, testMonth).atEndOfMonth().atTime(LocalTime.MAX);
+    Instant testStart =
+        YearMonth.of(testYear, testMonth).atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC);
+    Instant testEnd =
+        YearMonth.of(testYear, testMonth)
+            .atEndOfMonth()
+            .atTime(LocalTime.MAX)
+            .toInstant(ZoneOffset.UTC);
     List<DiaryIndexProjection> testProjection =
         TestDiaryObjectFactory.getTestDiaryIndexProjections_2024_03_Data_Of_2();
+    Instant requestYearMonth =
+        LocalDate.of(testYear, testMonth, 1).atStartOfDay(ZoneId.of("UTC")).toInstant();
 
     when(mockDiaryRepository.findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd))
         .thenReturn(Optional.of(testProjection));
-    DiaryIndexResponse indexes =
-        diaryService.getIndex(member.getId(), YearMonth.of(testYear, testMonth));
+    DiaryIndexResponse indexes = diaryService.getIndex(member.getId(), requestYearMonth);
 
     List<DiaryIndexProjection> responseIndexes = indexes.getDiaryIndexes();
     DiaryIndexProjection first = responseIndexes.get(0);
@@ -167,14 +175,19 @@ public class DiaryServiceTest {
   void yearMonthZeroSuccess() {
     int testYear = 2024;
     int testMonth = 2;
-    LocalDateTime testStart = YearMonth.of(testYear, testMonth).atDay(1).atStartOfDay();
-    LocalDateTime testEnd = YearMonth.of(testYear, testMonth).atEndOfMonth().atTime(LocalTime.MAX);
-
+    Instant testStart =
+        YearMonth.of(testYear, testMonth).atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC);
+    Instant testEnd =
+        YearMonth.of(testYear, testMonth)
+            .atEndOfMonth()
+            .atTime(LocalTime.MAX)
+            .toInstant(ZoneOffset.UTC);
+    Instant requestYearMonth =
+        LocalDate.of(testYear, testMonth, 1).atStartOfDay(ZoneId.of("UTC")).toInstant();
     when(mockDiaryRepository.findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd))
         .thenReturn(Optional.empty());
 
-    DiaryIndexResponse indexes =
-        diaryService.getIndex(member.getId(), YearMonth.of(testYear, testMonth));
+    DiaryIndexResponse indexes = diaryService.getIndex(member.getId(), requestYearMonth);
 
     List<DiaryIndexProjection> responseIndexes = indexes.getDiaryIndexes();
     System.out.println("responseIndexes = " + responseIndexes);
@@ -186,7 +199,7 @@ public class DiaryServiceTest {
   @DisplayName("일기 상세 조회 성공")
   void getDiarySuccess() {
     // given
-    LocalDate requestDate = NOW_DATE_TIME.toLocalDate();
+    Instant requestDate = NOW_DATE_TIME;
     when(mockDiaryRepository.findByMemberIdAndDate(anyLong(), any(LocalDate.class)))
         .thenReturn(Optional.of(diary));
     List<String> preSignedWebtoon = List.of("pre-sigend-webtoon");
@@ -206,7 +219,7 @@ public class DiaryServiceTest {
               assertThat(r.getWebtoonImageUrls()).isEqualTo(preSignedWebtoon);
               assertThat(r.getBgmUrl()).isEqualTo(preSignedBgm);
               assertThat(r.getAiComment()).isEqualTo(diary.getAiComment());
-              assertThat(r.getDate()).isEqualTo(diary.getDiaryCreatedTime().toLocalDate());
+              assertThat(r.getDateTime()).isEqualTo(diary.getDiaryCreatedTime());
             });
 
     verify(mockDiaryRepository, times(1)).findByMemberIdAndDate(anyLong(), any(LocalDate.class));
@@ -215,7 +228,7 @@ public class DiaryServiceTest {
   @Test
   @DisplayName("일기 상세 조회 실패 - 일기를 찾을 수 없음")
   void getDiaryFail() {
-    LocalDate requestDate = NOW_DATE_TIME.toLocalDate();
+    Instant requestDate = NOW_DATE_TIME;
 
     when(mockDiaryRepository.findByMemberIdAndDate(anyLong(), any(LocalDate.class)))
         .thenReturn(Optional.empty());

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.heartsave.todaktodak_api.common.converter.InstantConverter;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageService;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
@@ -22,7 +23,7 @@ import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreview
 import com.heartsave.todaktodak_api.diary.exception.PublicDiaryNotFoundException;
 import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.MySharedDiaryRepository;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -126,7 +127,7 @@ public class MySharedDiaryServiceTest {
   @Test
   @DisplayName("나의 공개 일기 상세를 성공적으로 조회한다")
   void getDiary_Success() {
-    LocalDate requestDate = LocalDate.now();
+    Instant requestDate = Instant.now();
     MySharedDiaryContentOnlyProjection contentOnly = mock(MySharedDiaryContentOnlyProjection.class);
     DiaryReactionCountProjection reactionCount = mock(DiaryReactionCountProjection.class);
     List<DiaryReactionType> memberReactions =
@@ -137,7 +138,8 @@ public class MySharedDiaryServiceTest {
     when(contentOnly.getWebtoonImageUrls()).thenReturn(List.of(webtoonUrl));
     when(contentOnly.getBgmUrl()).thenReturn(bgmUrl);
 
-    when(mySharedDiaryRepository.findContentOnly(memberId, requestDate))
+    when(mySharedDiaryRepository.findContentOnly(
+            memberId, InstantConverter.toLocalDate(requestDate)))
         .thenReturn(Optional.of(contentOnly));
     when(reactionRepository.countEachByDiaryId(diaryId)).thenReturn(reactionCount);
     when(reactionRepository.findMemberReaction(memberId, diaryId)).thenReturn(memberReactions);
@@ -164,8 +166,9 @@ public class MySharedDiaryServiceTest {
   @DisplayName("존재하지 않는 날짜의 공유된 일기 조회시 예외를 던진다")
   void getDiary_ThrowsException_WhenDiaryNotFound() {
     // Given
-    LocalDate requestDate = LocalDate.now();
-    when(mySharedDiaryRepository.findContentOnly(memberId, requestDate))
+    Instant requestDate = Instant.now();
+    when(mySharedDiaryRepository.findContentOnly(
+            memberId, InstantConverter.toLocalDate(requestDate)))
         .thenReturn(Optional.empty());
 
     // When & Then

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/PublicDiaryServiceTest.java
@@ -27,7 +27,7 @@ import com.heartsave.todaktodak_api.diary.repository.DiaryReactionRepository;
 import com.heartsave.todaktodak_api.diary.repository.DiaryRepository;
 import com.heartsave.todaktodak_api.diary.repository.PublicDiaryRepository;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -183,7 +183,7 @@ class PublicDiaryServiceTest {
     when(content.getBgmUrl()).thenReturn("bgm/music.mp3");
     when(content.getNickname()).thenReturn("nickname");
     when(content.getPublicContent()).thenReturn("content");
-    when(content.getDate()).thenReturn(LocalDate.now());
+    when(content.getDate()).thenReturn(Instant.now());
 
     // S3 URL 생성 mock
     List<String> mockWebtoonUrls = List.of("presigned-webtoon-url");


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- Web Client에서 사용하는 DTO의 시간 객체를 모두 ```Instant``` 타입으로 변경하였습니다.
- DB에 저장하는 Entity의 시간 객체 또한 ```Instant``` 타입으로 변경하였습니다.

## 리뷰 받고 싶은 내용

- 궁금하신 부분 있으시면 편하게 알려주세요!

## 테스트 및 결과
- 로컬 테스트 시간 객체 또한 알맞게 변경
- 테스트 확인 완료

## 관련 스크린샷 및 참고자료 (Optional)

close #112 
