### PR TITLE
Oauth2 리소스 및 401/403 응답 에러 테스트

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/AuthErrorSpec.java
@@ -16,7 +16,7 @@ public enum AuthErrorSpec implements ErrorSpec {
   EMAIL_OTP_SEND_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "AUTH-006", "인증번호 전송이 실패됐습니다.", "OPT 전송 실패"),
   INCORRECT_EMAIL_OTP(HttpStatus.CONFLICT, "AUTH-007", "잘못된 인증번호입니다.", "OPT 검증 실패"),
   ABNORMAL_ACCESS(HttpStatus.UNAUTHORIZED, "AUTH-008", "로그인이 필요합니다.", "비정상 접근 시도"),
-  AUTH_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-009", "인증이 실패했습니다", "비정상 인증 에러"),
+  AUTH_FAIL(HttpStatus.UNAUTHORIZED, "AUTH-009", "로그인이 필요합니다.", "비정상 인증 에러"),
   RE_LOGIN_REQUIRED(
       HttpStatus.UNAUTHORIZED, "AUTH-010", "다시 로그인을 해야합니다.", "리프레시 토큰 유효성 검사가 실패됐습니다."),
   TEMP_USER_DIARY_CREATE_FAIL(

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AccessDeniedHandlerImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AccessDeniedHandlerImpl.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
@@ -14,6 +16,7 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 
 @RequiredArgsConstructor
 public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final ObjectMapper objectMapper;
 
   @Override
@@ -22,6 +25,7 @@ public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
       HttpServletResponse response,
       AccessDeniedException accessDeniedException)
       throws IOException {
+    logger.error("인가 에러가 발생했습니다: {}", accessDeniedException.getMessage());
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpStatus.FORBIDDEN.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
@@ -59,7 +59,9 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
     } catch (Exception ex) {
       response
           .getWriter()
-          .write(objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.AUTH_FAIL)));
+          .write(
+              objectMapper.writeValueAsString(
+                  ErrorResponse.from(AuthErrorSpec.valueOf(e.getMessage()))));
     }
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
@@ -64,6 +64,7 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
               objectMapper.writeValueAsString(
                   ErrorResponse.from(AuthErrorSpec.valueOf(e.getMessage()))));
     } catch (Exception ex) {
+      logger.error("예기치 못한 인증 에러 발생: {}", e.getMessage());
       response
           .getWriter()
           .write(objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.AUTH_FAIL)));

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImpl.java
@@ -3,6 +3,7 @@ package com.heartsave.todaktodak_api.common.security.component;
 import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.NO_TOKEN_REQUEST_ATTRIBUTE_KEY;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.auth.exception.AuthException;
 import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
 import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
 import com.heartsave.todaktodak_api.common.exception.errorspec.ErrorSpec;
@@ -56,12 +57,16 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
     try {
       TokenErrorSpec spec = TokenErrorSpec.valueOf(e.getMessage());
       response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.from(spec)));
-    } catch (Exception ex) {
+    } catch (AuthException ex) {
       response
           .getWriter()
           .write(
               objectMapper.writeValueAsString(
                   ErrorResponse.from(AuthErrorSpec.valueOf(e.getMessage()))));
+    } catch (Exception ex) {
+      response
+          .getWriter()
+          .write(objectMapper.writeValueAsString(ErrorResponse.from(AuthErrorSpec.AUTH_FAIL)));
     }
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/jwt/JwtValidationFilter.java
@@ -90,6 +90,8 @@ public class JwtValidationFilter extends OncePerRequestFilter {
         | IllegalArgumentException e) {
       logger.error("유효하지 않은 토큰입니다. {}", token);
       respondAuthError(request, response, TokenErrorSpec.INVALID_TOKEN.name());
+    } catch (Exception e) {
+      logger.error("토큰 검증이 실패했습니다. {}", e.getMessage());
     }
     return false;
   }

--- a/src/test/java/com/heartsave/todaktodak_api/common/BaseTestObject.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/BaseTestObject.java
@@ -3,6 +3,7 @@ package com.heartsave.todaktodak_api.common;
 import com.heartsave.todaktodak_api.common.security.domain.AuthType;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
+import com.heartsave.todaktodak_api.member.domain.TodakRole;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -33,6 +34,12 @@ public class BaseTestObject {
   private static String TEST_CHARACTER_STYLE = "romance";
   private static int TEST_CHARACTER_SEED = 13564;
 
+  public static MemberEntity createTempMember() {
+    var member = createMember();
+    member.updateRole(TodakRole.ROLE_TEMP.name());
+    return member;
+  }
+
   public static MemberEntity createMember() {
     return MemberEntity.builder()
         .id(1L)
@@ -45,6 +52,7 @@ public class BaseTestObject {
         .characterImageUrl(TEST_CHARACTER_IMAGE_URL)
         .characterStyle(TEST_CHARACTER_STYLE)
         .characterSeed(TEST_CHARACTER_SEED)
+        .role(TodakRole.ROLE_USER)
         .build();
   }
 

--- a/src/test/java/com/heartsave/todaktodak_api/common/security/component/AccessDeniedHandlerImplTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/security/component/AccessDeniedHandlerImplTest.java
@@ -1,0 +1,48 @@
+package com.heartsave.todaktodak_api.common.security.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
+import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+final class AccessDeniedHandlerImplTest {
+  private AccessDeniedHandlerImpl accessDeniedHandler;
+  private ObjectMapper objectMapper;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  @BeforeEach
+  void setup() {
+    objectMapper = new ObjectMapper();
+    accessDeniedHandler = new AccessDeniedHandlerImpl(objectMapper);
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  @DisplayName("권한이 없는 사용자의 인가 에러 처리")
+  void forbiddenResponseTest() throws Exception {
+    // when
+    accessDeniedHandler.handle(request, response, new AccessDeniedException(""));
+
+    // then
+    assertThat(response.getContentType()).contains(StandardCharsets.UTF_8.name());
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    ErrorResponse errorResponse =
+        objectMapper.readValue(response.getContentAsString(), ErrorResponse.class);
+    assertThat(errorResponse.getTitle())
+        .isEqualTo(AuthErrorSpec.TEMP_USER_DIARY_CREATE_FAIL.name());
+    assertThat(errorResponse.getMessage())
+        .isEqualTo(AuthErrorSpec.TEMP_USER_DIARY_CREATE_FAIL.getClientMessage());
+  }
+}

--- a/src/test/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImplTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/security/component/AuthenticationEntryPointImplTest.java
@@ -1,0 +1,90 @@
+package com.heartsave.todaktodak_api.common.security.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heartsave.todaktodak_api.common.exception.ErrorResponse;
+import com.heartsave.todaktodak_api.common.exception.errorspec.AuthErrorSpec;
+import com.heartsave.todaktodak_api.common.exception.errorspec.TokenErrorSpec;
+import com.heartsave.todaktodak_api.common.security.constant.JwtConstant;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+final class AuthenticationEntryPointImplTest {
+  private ObjectMapper objectMapper;
+  private AuthenticationEntryPointImpl authenticationEntryPoint;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  @BeforeEach
+  void setup() {
+    objectMapper = new ObjectMapper();
+    authenticationEntryPoint = new AuthenticationEntryPointImpl(objectMapper);
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  @DisplayName("인증이 필요하지만 토큰과 쿠키가 없는 경우 비정상 접근 시도로 간주")
+  void abnormalAccess_noRefreshCookie() throws Exception {
+    // given
+    request.setAttribute(JwtConstant.NO_TOKEN_REQUEST_ATTRIBUTE_KEY, AuthErrorSpec.ABNORMAL_ACCESS);
+
+    // when
+    authenticationEntryPoint.commence(request, response, new BadCredentialsException(""));
+
+    // then
+    assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    assertThat(response.getContentType()).contains(MediaType.APPLICATION_JSON_VALUE);
+
+    ErrorResponse errorResponse =
+        objectMapper.readValue(response.getContentAsString(), ErrorResponse.class);
+    assertThat(errorResponse.getTitle()).isEqualTo(AuthErrorSpec.ABNORMAL_ACCESS.name());
+  }
+
+  @Test
+  @DisplayName("인증이 필요하지만 토큰이 없고 쿠키가 있는 경우 토큰 재발급 필요로 간주")
+  void unauthorized_nonExistentTokenWithCookie() throws Exception {
+    // given
+    request.setAttribute(
+        JwtConstant.NO_TOKEN_REQUEST_ATTRIBUTE_KEY, TokenErrorSpec.NON_EXISTENT_TOKEN);
+
+    // when
+    authenticationEntryPoint.commence(request, response, new BadCredentialsException(""));
+
+    // then
+    ErrorResponse errorResponse =
+        objectMapper.readValue(response.getContentAsString(), ErrorResponse.class);
+    assertThat(errorResponse.getTitle()).isEqualTo(TokenErrorSpec.NON_EXISTENT_TOKEN.name());
+  }
+
+  @ParameterizedTest
+  @DisplayName("토큰 유효성 검사 실패로 인한 응답")
+  @MethodSource("tokenErrorSpecs")
+  void unauthorized_invalidToken(TokenErrorSpec spec) throws Exception {
+    // when
+    authenticationEntryPoint.commence(request, response, new BadCredentialsException(spec.name()));
+
+    // then
+    ErrorResponse errorResponse =
+        objectMapper.readValue(response.getContentAsString(), ErrorResponse.class);
+    assertThat(errorResponse.getTitle()).isEqualTo(spec.name());
+    assertThat(errorResponse.getMessage()).isEqualTo(spec.getClientMessage());
+  }
+
+  static Stream<TokenErrorSpec> tokenErrorSpecs() {
+    return Stream.of(TokenErrorSpec.EXPIRED_TOKEN, TokenErrorSpec.INVALID_TOKEN);
+  }
+}

--- a/src/test/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2AttributeTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/common/security/component/oauth2/TodakOauth2AttributeTest.java
@@ -1,0 +1,85 @@
+package com.heartsave.todaktodak_api.common.security.component.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.heartsave.todaktodak_api.common.BaseTestObject;
+import com.heartsave.todaktodak_api.common.security.domain.AuthType;
+import com.heartsave.todaktodak_api.member.entity.MemberEntity;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+final class TodakOauth2AttributeTest {
+  private MemberEntity member = BaseTestObject.createTempMember();
+  private static final String attributeId = "12345";
+
+  @Test
+  @DisplayName("카카오 리소스")
+  void attributeAsKakaoTest() {
+    // given
+    var attribute = Map.of("id", attributeId, "kakao_account", Map.of("email", member.getEmail()));
+
+    // when
+    TodakOauth2Attribute oauth2Attribute =
+        TodakOauth2Attribute.of(attribute, AuthType.KAKAO.name());
+
+    // then
+    assertThat(oauth2Attribute.getUsername()).isEqualTo(attributeId + "_" + AuthType.KAKAO.name());
+  }
+
+  @Test
+  @DisplayName("네이버 리소스")
+  void attributeAsNaverTest() {
+    // given
+    var attribute = Map.of("response", Map.of("id", attributeId), "email", member.getEmail());
+
+    // when
+    TodakOauth2Attribute oauth2Attribute =
+        TodakOauth2Attribute.of(attribute, AuthType.NAVER.name());
+
+    // then
+    assertThat(oauth2Attribute.getUsername()).isEqualTo(attributeId + "_" + AuthType.NAVER.name());
+  }
+
+  @Test
+  @DisplayName("구글 리소스")
+  void attributeAsGoogleTest() {
+    // given
+    Map<String, Object> attribute = Map.of("sub", attributeId, "email", member.getEmail());
+
+    // when
+    TodakOauth2Attribute oauth2Attribute =
+        TodakOauth2Attribute.of(attribute, AuthType.GOOGLE.name());
+
+    // then
+    assertThat(oauth2Attribute.getUsername()).isEqualTo(attributeId + "_" + AuthType.GOOGLE.name());
+  }
+
+  @Test
+  @DisplayName("지원하지 않는 소셜 로그인")
+  void unsupoortedOauth2FailTest() {
+    // given
+    Map<String, Object> attribute = Map.of();
+
+    // when
+    TodakOauth2Attribute oauth2Attribute = TodakOauth2Attribute.of(attribute, "UNKNOWN");
+
+    // then
+    assertThat(oauth2Attribute).isEqualTo(null);
+  }
+
+  @Test
+  @DisplayName("정확하지 않은 리소스 형식")
+  void wrongAttributeFormatTest() {
+    // given
+    Map<String, Object> attribute = Map.of();
+
+    // when
+    TodakOauth2Attribute oauth2Attribute =
+        TodakOauth2Attribute.of(attribute, AuthType.KAKAO.name());
+
+    // then
+    assertThat(oauth2Attribute).isEqualTo(null);
+  }
+}

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
@@ -184,9 +184,9 @@ class MySharedDiaryRepositoryTest {
     assertThat(actual.getBgmUrl())
         .as("BGM URL이 일치해야 합니다")
         .contains(expected.getDiaryEntity().getBgmUrl());
-    assertThat(actual.getDiaryCreatedDate())
+    assertThat(actual.getDiaryCreatedDate().truncatedTo(ChronoUnit.SECONDS))
         .as("일기 작성 날짜가 일치해야 합니다")
-        .isEqualTo(expected.getDiaryEntity().getDiaryCreatedTime().truncatedTo(ChronoUnit.MILLIS));
+        .isEqualTo(expected.getDiaryEntity().getDiaryCreatedTime().truncatedTo(ChronoUnit.SECONDS));
   }
 
   @Test


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

1. Oauth2 리소스 변환 테스트(`Oauth2Request`의  `attribute` -> `TodakOauth2Attribute`)
**변환 실패시 에러 처리 리팩토링**

2. 401, 403 에러 응답 테스트

원래 Oauth2 회원가입 및 로그인 테스트도 수행하려했으나,
Oauth2 인증 코드, 액세스 토큰, 리소스 응답을 mocking하는 과정이 다소 번거로워 미진행했습니다.

## 리뷰 받고 싶은 내용

- 궁금하신 점이 있다면 코멘트 부탁드립니다. ^0^

## 테스트 및 결과
- 로컬 테스트 완료

## 관련 스크린샷 및 참고자료 (Optional)
close #110 