### PR TITLE
캐릭터 이미지 등록 흐름 개선

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
@@ -6,8 +6,10 @@ import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageManager;
 import com.heartsave.todaktodak_api.event.constant.EventType;
 import com.heartsave.todaktodak_api.event.entity.EventEntity;
 import com.heartsave.todaktodak_api.event.service.EventService;
+import com.heartsave.todaktodak_api.member.domain.CharacterCache;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
+import com.heartsave.todaktodak_api.member.repository.CharacterCacheRepository;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,12 +19,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class AiWebhookCharacterService {
-  private final MemberRepository memberRepository;
   private final EventService eventService;
   private final S3FileStorageManager s3Manager;
+  private final MemberRepository memberRepository;
+  private final CharacterCacheRepository characterCacheRepository;
 
+  @Transactional(readOnly = true)
   public void saveCharacterAndNotify(WebhookCharacterCompletionRequest dto) {
-    MemberEntity member = saveCharacter(dto);
+    MemberEntity member = cacheTempCharacter(dto);
 
     eventService.send(
         EventEntity.builder()
@@ -32,15 +36,21 @@ public class AiWebhookCharacterService {
             .build());
   }
 
-  private MemberEntity saveCharacter(WebhookCharacterCompletionRequest dto) {
+  private MemberEntity cacheTempCharacter(WebhookCharacterCompletionRequest dto) {
     Long memberId = dto.memberId();
     MemberEntity retrievedMember =
         memberRepository
             .findById(memberId)
             .orElseThrow(() -> new MemberNotFoundException(MemberErrorSpec.NOT_FOUND, memberId));
     String url = s3Manager.parseKeyFrom(dto.characterProfileImageUrl());
-    retrievedMember.updateCharacterInfo(
-        dto.characterInfo(), dto.characterStyle(), dto.seedNum(), url);
+    characterCacheRepository.save(
+        CharacterCache.builder()
+            .id(dto.memberId())
+            .characterInfo(dto.characterInfo())
+            .characterStyle(dto.characterStyle())
+            .characterSeed(dto.seedNum())
+            .characterImageUrl(url)
+            .build());
     return retrievedMember;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterService.java
@@ -24,7 +24,6 @@ public class AiWebhookCharacterService {
   private final MemberRepository memberRepository;
   private final CharacterCacheRepository characterCacheRepository;
 
-  @Transactional(readOnly = true)
   public void saveCharacterAndNotify(WebhookCharacterCompletionRequest dto) {
     MemberEntity member = cacheTempCharacter(dto);
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 public final class CoreConstant {
   public static class URL {
     public static final String DEFAULT_URL = "";
-    public static final String CHARACTER_IMAGE_URL_PREFIX = "profile";
     public static final String TEMP_CHARACTER_IMAGE_URL_PREFIX = "temp_";
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 public final class CoreConstant {
   public static class URL {
     public static final String DEFAULT_URL = "";
+    public static final String CHARACTER_IMAGE_URL_PREFIX = "profile";
+    public static final String TEMP_CHARACTER_IMAGE_URL_PREFIX = "temp_";
   }
 
   public static class TIME_FORMAT {

--- a/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/MemberErrorSpec.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/exception/errorspec/MemberErrorSpec.java
@@ -8,7 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum MemberErrorSpec implements ErrorSpec {
-  NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "회원님의 정보를 찾을 수 없습니다.", "서비스에 등록되어 있지 않은 사용자 입니다.");
+  NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "회원님의 정보를 찾을 수 없습니다.", "서비스에 등록되어 있지 않은 사용자 입니다."),
+  TEMP_CHARACTER_EXPIRED(
+      HttpStatus.CONFLICT,
+      "MEMBER-002",
+      "임시 캐릭터가 만료됐습니다. 캐릭터를 다시 생성해주세요.",
+      "캐릭터 등록 과정에서 캐시 데이터가 만료됐습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageManager.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageManager.java
@@ -114,15 +114,10 @@ public class S3FileStorageManager {
   }
 
   // 생성된 임시 캐릭터를 프로필로 등록
-  public boolean replaceCharacterImageUrl(String key) {
-    String originKey = TEMP_CHARACTER_IMAGE_URL_PREFIX + key;
-    try {
-      copyObject(originKey, key);
-      deleteObject(originKey);
-      return true;
-    } catch (Exception e) {
-      return false;
-    }
+  public void replaceCharacterImageUrl(String tempKey) {
+    String key = tempKey.substring(TEMP_CHARACTER_IMAGE_URL_PREFIX.length());
+    copyObject(tempKey, key);
+    deleteObject(tempKey);
   }
 
   private void copyObject(String from, String to) {

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageManager.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageManager.java
@@ -85,7 +85,7 @@ public class S3FileStorageManager {
     return preSignedUrl;
   }
 
-  public void deleteDiary(String key) {
+  public void deleteDiaryContent(String key) {
     if (DEFAULT_URL.equals(key) || !isObjectExist(key)) return;
 
     log.info("S3에 일기 컨텐츠 삭제를 요청합니다.");
@@ -93,8 +93,8 @@ public class S3FileStorageManager {
     log.info("S3에서 일기 컨텐츠를 삭제했습니다.");
   }
 
-  public void deleteDiaries(List<String> keys) {
-    keys.forEach(this::deleteDiary);
+  public void deleteDiaryContents(List<String> keys) {
+    keys.forEach(this::deleteDiaryContent);
   }
 
   // 객체 메타데이터 조회로 존재 확인

--- a/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageManager.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/storage/s3/S3FileStorageManager.java
@@ -115,9 +115,13 @@ public class S3FileStorageManager {
 
   // 생성된 임시 캐릭터를 프로필로 등록
   public void replaceCharacterImageUrl(String tempKey) {
-    String key = tempKey.substring(TEMP_CHARACTER_IMAGE_URL_PREFIX.length());
-    copyObject(tempKey, key);
-    deleteObject(tempKey);
+    String key = tempKey.replace(TEMP_CHARACTER_IMAGE_URL_PREFIX, "");
+    try {
+      copyObject(tempKey, key);
+      deleteObject(tempKey);
+    } catch (NoSuchKeyException e) {
+      throw new InvalidS3UrlException(S3ErrorSpec.INVALID_S3_URL, tempKey + "->" + key);
+    }
   }
 
   private void copyObject(String from, String to) {

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -67,7 +67,8 @@ public class DiaryService {
                     new DiaryNotFoundException(DiaryErrorSpec.DIARY_NOT_FOUND, memberId, diaryId));
     diaryRepository.delete(diary);
     log.info("DB에서 일기를 삭제했습니다.");
-    s3FileStorageManager.deleteDiaries(List.of(diary.getWebtoonImageUrl(), diary.getBgmUrl()));
+    s3FileStorageManager.deleteDiaryContents(
+        List.of(diary.getWebtoonImageUrl(), diary.getBgmUrl()));
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -67,7 +67,7 @@ public class DiaryService {
                     new DiaryNotFoundException(DiaryErrorSpec.DIARY_NOT_FOUND, memberId, diaryId));
     diaryRepository.delete(diary);
     log.info("DB에서 일기를 삭제했습니다.");
-    s3FileStorageManager.deleteObjects(List.of(diary.getWebtoonImageUrl(), diary.getBgmUrl()));
+    s3FileStorageManager.deleteDiaries(List.of(diary.getWebtoonImageUrl(), diary.getBgmUrl()));
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/heartsave/todaktodak_api/event/service/EventService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/service/EventService.java
@@ -6,9 +6,4 @@ public interface EventService {
   void save(EventEntity event);
 
   void send(EventEntity event);
-
-  default void saveAndSend(EventEntity event) {
-    save(event);
-    send(event);
-  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/event/service/SseEventService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/event/service/SseEventService.java
@@ -28,6 +28,7 @@ public class SseEventService implements EventService {
 
   @Override
   public void save(EventEntity event) {
+    logger.info("{}에 대한 이벤트를 저장합니다.", event.getMemberEntity().getId());
     eventRepository.save(event);
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
@@ -50,6 +50,6 @@ public class CharacterController {
   @PostMapping("/register")
   public ResponseEntity<CharacterRegisterResponse> completeCharacterRegister(
       @TodakUserId Long memberId, HttpServletResponse response) {
-    return ResponseEntity.ok(characterService.changeRoleAndReissueToken(memberId, response));
+    return ResponseEntity.ok(characterService.registerCharacterAndChangeRole(memberId, response));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/controller/CharacterController.java
@@ -1,8 +1,8 @@
 package com.heartsave.todaktodak_api.member.controller;
 
 import com.heartsave.todaktodak_api.auth.annotation.TodakUserId;
+import com.heartsave.todaktodak_api.member.dto.response.CharacterImageResponse;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterRegisterResponse;
-import com.heartsave.todaktodak_api.member.dto.response.CharacterTemporaryImageResponse;
 import com.heartsave.todaktodak_api.member.service.CharacterService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -26,9 +26,8 @@ public class CharacterController {
         @ApiResponse(responseCode = "404", description = "회원 조회 실패")
       })
   @GetMapping
-  public ResponseEntity<CharacterTemporaryImageResponse> getPastCharacterImage(
-      @TodakUserId Long memberId) {
-    return ResponseEntity.ok(characterService.getPastCharacterImage(memberId));
+  public ResponseEntity<CharacterImageResponse> getCharacterImage(@TodakUserId Long memberId) {
+    return ResponseEntity.ok(characterService.getCharacterImage(memberId));
   }
 
   @ApiResponses(

--- a/src/main/java/com/heartsave/todaktodak_api/member/domain/CharacterCache.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/domain/CharacterCache.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.core.RedisHash;
 @Builder
 @RedisHash(value = "character", timeToLive = 172800) // 2일
 public record CharacterCache(
-    @Id String id,
+    @Id Long id,
     String characterInfo,
     String characterStyle,
     Integer characterSeed,

--- a/src/main/java/com/heartsave/todaktodak_api/member/domain/CharacterCache.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/domain/CharacterCache.java
@@ -1,0 +1,14 @@
+package com.heartsave.todaktodak_api.member.domain;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import org.springframework.data.redis.core.RedisHash;
+
+@Builder
+@RedisHash(value = "character", timeToLive = 172800) // 2일
+public record CharacterCache(
+    @Id String id,
+    String characterInfo,
+    String characterStyle,
+    Integer characterSeed,
+    String characterImageUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/member/dto/response/CharacterImageResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/dto/response/CharacterImageResponse.java
@@ -1,0 +1,12 @@
+package com.heartsave.todaktodak_api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "회원 캐릭터 이미지 응답 객체")
+public record CharacterImageResponse(
+    @Schema(example = "temp_profile.webp", description = "생성됐지만 미등록된 캐릭터 이미지 주소")
+        String tempCharacterImageUrl,
+    @Schema(example = "profile.webp", description = "등록된 회원 캐릭터 이미지 주소")
+        String characterImageUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/member/dto/response/CharacterTemporaryImageResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/dto/response/CharacterTemporaryImageResponse.java
@@ -1,9 +1,0 @@
-package com.heartsave.todaktodak_api.member.dto.response;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-
-@Builder
-@Schema(description = "회원 캐릭터 생성 과정에서 기존에 생성된 회원 캐릭터 이미지 응답 객체")
-public record CharacterTemporaryImageResponse(
-    @Schema(example = "character/123", description = "회원 캐릭터 이미지 주소") String characterImageUrl) {}

--- a/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
@@ -62,7 +62,6 @@ public class MemberEntity extends BaseEntity {
     characterInfo = cache.characterInfo();
     characterStyle = cache.characterStyle();
     characterSeed = cache.characterSeed();
-    characterImageUrl =
-        cache.characterImageUrl().substring(TEMP_CHARACTER_IMAGE_URL_PREFIX.length());
+    characterImageUrl = cache.characterImageUrl().replace(TEMP_CHARACTER_IMAGE_URL_PREFIX, "");
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/entity/MemberEntity.java
@@ -1,9 +1,11 @@
 package com.heartsave.todaktodak_api.member.entity;
 
 import static com.heartsave.todaktodak_api.common.constant.ConstraintConstant.Member.*;
+import static com.heartsave.todaktodak_api.common.constant.CoreConstant.URL.TEMP_CHARACTER_IMAGE_URL_PREFIX;
 
 import com.heartsave.todaktodak_api.common.entity.BaseEntity;
 import com.heartsave.todaktodak_api.common.security.domain.AuthType;
+import com.heartsave.todaktodak_api.member.domain.CharacterCache;
 import com.heartsave.todaktodak_api.member.domain.TodakRole;
 import jakarta.persistence.*;
 import lombok.*;
@@ -56,11 +58,11 @@ public class MemberEntity extends BaseEntity {
     this.role = TodakRole.valueOf(role);
   }
 
-  public void updateCharacterInfo(
-      String characterInfo, String characterStyle, Integer characterSeed, String characterUrl) {
-    this.characterInfo = characterInfo;
-    this.characterStyle = characterStyle;
-    this.characterSeed = characterSeed;
-    this.characterImageUrl = characterUrl;
+  public void updateCharacterInfo(CharacterCache cache) {
+    characterInfo = cache.characterInfo();
+    characterStyle = cache.characterStyle();
+    characterSeed = cache.characterSeed();
+    characterImageUrl =
+        cache.characterImageUrl().substring(TEMP_CHARACTER_IMAGE_URL_PREFIX.length());
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/exception/MemberException.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/exception/MemberException.java
@@ -1,13 +1,12 @@
 package com.heartsave.todaktodak_api.member.exception;
 
-
 import com.heartsave.todaktodak_api.common.exception.BaseException;
 import com.heartsave.todaktodak_api.common.exception.ErrorFieldBuilder;
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 
 public class MemberException extends BaseException {
 
-  protected MemberException(MemberErrorSpec errorSpec, Long memberId) {
+  public MemberException(MemberErrorSpec errorSpec, Long memberId) {
     super(errorSpec, ErrorFieldBuilder.builder().add("memberId", memberId).build());
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/member/repository/CharacterCacheRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/repository/CharacterCacheRepository.java
@@ -1,0 +1,7 @@
+package com.heartsave.todaktodak_api.member.repository;
+
+import com.heartsave.todaktodak_api.member.domain.CharacterCache;
+import org.springframework.data.repository.CrudRepository;
+
+// TODO: String으로 ID를 지정해야할 수도 있음
+public interface CharacterCacheRepository extends CrudRepository<CharacterCache, Long> {}

--- a/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/member/service/CharacterService.java
@@ -1,6 +1,5 @@
 package com.heartsave.todaktodak_api.member.service;
 
-import static com.heartsave.todaktodak_api.common.constant.CoreConstant.URL.TEMP_CHARACTER_IMAGE_URL_PREFIX;
 import static com.heartsave.todaktodak_api.common.security.constant.JwtConstant.REFRESH_TOKEN_COOKIE_KEY;
 
 import com.heartsave.todaktodak_api.ai.client.dto.request.ClientCharacterRequest;
@@ -11,6 +10,7 @@ import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.security.util.CookieUtils;
 import com.heartsave.todaktodak_api.common.security.util.JwtUtils;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageManager;
+import com.heartsave.todaktodak_api.member.domain.CharacterCache;
 import com.heartsave.todaktodak_api.member.domain.TodakRole;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterImageResponse;
 import com.heartsave.todaktodak_api.member.dto.response.CharacterRegisterResponse;
@@ -97,11 +97,12 @@ public class CharacterService {
 
   @Nullable
   private String getTempCharacterImageUrl(MemberEntity member) {
-    if (!characterCacheRepository.existsById(member.getId())) {
+    CharacterCache cache = characterCacheRepository.findById(member.getId()).orElse(null);
+    if (cache == null) {
       logger.warn("최근에 {}의 캐릭터가 생성된 적이 없습니다.", member.getId());
       return null;
     }
-    String tempCharacterImageUrl = TEMP_CHARACTER_IMAGE_URL_PREFIX + member.getCharacterImageUrl();
+    String tempCharacterImageUrl = cache.characterImageUrl();
     return getPreSignedCharacterImageUrl(tempCharacterImageUrl);
   }
 

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/service/AiWebhookCharacterServiceTest.java
@@ -13,6 +13,7 @@ import com.heartsave.todaktodak_api.event.exception.EventException;
 import com.heartsave.todaktodak_api.event.service.EventService;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.exception.MemberNotFoundException;
+import com.heartsave.todaktodak_api.member.repository.CharacterCacheRepository;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,7 @@ final class AiWebhookCharacterServiceTest {
   @Mock private MemberRepository memberRepository;
   @Mock private S3FileStorageManager s3FileStorageManager;
   @Mock private EventService eventService;
+  @Mock private CharacterCacheRepository characterCacheRepository;
   @InjectMocks private AiWebhookCharacterService characterService;
 
   private MemberEntity member;
@@ -49,7 +51,7 @@ final class AiWebhookCharacterServiceTest {
 
   @Test
   @DisplayName("캐릭터 웹훅에 대한 알림 성공")
-  void saveCharacterAndNotify_success() {
+  void cacheTempCharacterAndNotify_success() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     ArgumentCaptor<EventEntity> eventCaptor = ArgumentCaptor.forClass(EventEntity.class);
@@ -76,7 +78,7 @@ final class AiWebhookCharacterServiceTest {
 
   @Test
   @DisplayName("캐릭터 웹훅에 대한 알림 실패 - 이벤트 전송 오류")
-  void saveCharacterAndNotify_eventSendFail() {
+  void cacheTempCharacterAndNotify_eventSendFail() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     doThrow(new EventException(EventErrorSpec.EVENT_CONNECT_FAIL))
@@ -93,7 +95,7 @@ final class AiWebhookCharacterServiceTest {
 
   @Test
   @DisplayName("캐릭터 웹훅에 대한 알림 실패 - 존재하지 않는 회원")
-  void saveCharacterAndNotify_memberNotFound() {
+  void cacheTempCharacterAndNotify_memberNotFound() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.empty());
 

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -107,7 +107,7 @@ public class DiaryServiceTest {
   void diaryDeleteSuccess() {
     doNothing().when(mockDiaryRepository).delete(any(DiaryEntity.class));
     when(mockDiaryRepository.findById(diary.getId())).thenReturn(Optional.of(diary));
-    doNothing().when(mockS3Manager).deleteObjects(any(List.class));
+    doNothing().when(mockS3Manager).deleteDiaries(any(List.class));
     assertDoesNotThrow(
         () -> {
           diaryService.delete(member.getId(), diary.getId());

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -107,7 +107,7 @@ public class DiaryServiceTest {
   void diaryDeleteSuccess() {
     doNothing().when(mockDiaryRepository).delete(any(DiaryEntity.class));
     when(mockDiaryRepository.findById(diary.getId())).thenReturn(Optional.of(diary));
-    doNothing().when(mockS3Manager).deleteDiaries(any(List.class));
+    doNothing().when(mockS3Manager).deleteDiaryContents(any(List.class));
     assertDoesNotThrow(
         () -> {
           diaryService.delete(member.getId(), diary.getId());


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항
### 주요 변경사항
Redis를 활용하여
**등록 이전에 생성된 캐릭터**의 정보(화풍, 시드 값 등)를 캐싱하도록 했습니다.

> 캐릭터 조회, 생성 등록 흐름을 다음과 같이 변경했습니다.

### 캐릭터 조회
1. 캐싱된 캐릭터와 DB에 저장된 캐릭터의 객체 url을 presign하여 반환합니다.

```json
{
    "tempCharacterImageUrl": "presigned-s3-url",
    "characterImageUrl": "presigned-s3-url"
}
```
만약 존재하지 않으면 `null` 반환

### 캐릭터 생성
1. AI 서버가 생성한 캐릭터를 S3에 이미지를 업로드합니다. 파일 이름은 `temp_profile` prefix로 이름을 지어주도록 기대합니다.
2. 웹훅으로 전달받은 캐릭터 정보를 캐싱합니다. TTL은 2일입니다.

### 캐릭터 등록
1. 캐싱된 캐릭터 정보를 DB에 반영합니다.
2. S3의 `temp_profile` 객체를 `profile`로 copy합니다.
3. 캐시를 비웁니다.
4. 사용자 권한을 변경합니다.


## 리뷰 받고 싶은 내용
결합도가 높은 부분이 있다고 판단되면 수정하겠습니다 😃

## 관련 스크린샷 및 참고자료 (Optional)
close #121 