### PR TITLE
Feature/todak 272/ Instant와 locale 정보를 활용한 데이터 조회 로직 구성

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientBgmRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientBgmRequest.java
@@ -1,7 +1,7 @@
 package com.heartsave.todaktodak_api.ai.client.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -20,7 +20,7 @@ public class ClientBgmRequest {
 
   private ClientBgmRequest(DiaryEntity diary, MemberEntity member) {
     this.memberId = member.getId();
-    this.date = InstantConverter.toLocalDate(diary.getDiaryCreatedTime());
+    this.date = InstantUtils.toLocalDate(diary.getDiaryCreatedTime());
     this.content = diary.getContent();
     this.emotion = diary.getEmotion();
   }

--- a/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/ai/client/dto/request/ClientWebtoonRequest.java
@@ -1,7 +1,7 @@
 package com.heartsave.todaktodak_api.ai.client.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import java.time.LocalDate;
@@ -21,7 +21,7 @@ public class ClientWebtoonRequest {
 
   private ClientWebtoonRequest(DiaryEntity diary, MemberEntity member) {
     this.memberId = String.valueOf(member.getId());
-    this.date = InstantConverter.toLocalDate(diary.getDiaryCreatedTime());
+    this.date = InstantUtils.toLocalDate(diary.getDiaryCreatedTime());
     this.content = diary.getContent();
     this.characterInfo = member.getCharacterInfo();
     this.seedNum = member.getCharacterSeed();

--- a/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
@@ -13,4 +13,9 @@ public final class CoreConstant {
   public static class TIME_FORMAT {
     public static final String ISO_DATETIME_WITH_MILLISECONDS = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   }
+
+  public static class HEADER {
+    public static final String TIME_ZONE_KEY = "Todak-Time-Zone";
+    public static final String DEFAULT_TIME_ZONE = "UTC";
+  }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/constant/CoreConstant.java
@@ -16,6 +16,6 @@ public final class CoreConstant {
 
   public static class HEADER {
     public static final String TIME_ZONE_KEY = "Todak-Time-Zone";
-    public static final String DEFAULT_TIME_ZONE = "UTC";
+    public static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/common/converter/InstantConverter.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/converter/InstantConverter.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 public class InstantConverter {
   public static LocalDate toLocalDate(Instant instant) {
@@ -31,6 +32,25 @@ public class InstantConverter {
         .atZone(ZoneOffset.UTC)
         .withDayOfMonth(1)
         .plusMonths(1)
+        .minusNanos(1)
+        .toInstant();
+  }
+
+  public static Instant toDayStartAtZone(Instant instant, String zoneId) {
+    return instant
+        .atZone(ZoneId.of(zoneId))
+        .withHour(0)
+        .withMinute(0)
+        .withSecond(0)
+        .withNano(0)
+        .toInstant();
+  }
+
+  public static Instant toDayEndAtZone(Instant instant, String zoneId) {
+    return instant
+        .atZone(ZoneId.of(zoneId))
+        .truncatedTo(ChronoUnit.DAYS)
+        .plusDays(1)
         .minusNanos(1)
         .toInstant();
   }

--- a/src/main/java/com/heartsave/todaktodak_api/common/converter/InstantUtils.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/converter/InstantUtils.java
@@ -4,10 +4,9 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
-public class InstantConverter {
+public class InstantUtils {
   public static LocalDate toLocalDate(Instant instant) {
     return instant.atZone(ZoneId.of("UTC")).toLocalDate();
   }
@@ -16,9 +15,9 @@ public class InstantConverter {
     return instant.atZone(ZoneId.of("UTC")).toLocalDateTime();
   }
 
-  public static Instant toMonthStartDateTime(Instant yearMonth) {
+  public static Instant toMonthStartAtZone(Instant yearMonth, String zoneId) {
     return yearMonth
-        .atZone(ZoneOffset.UTC)
+        .atZone(ZoneId.of(zoneId))
         .withDayOfMonth(1)
         .withHour(0)
         .withMinute(0)
@@ -27,9 +26,9 @@ public class InstantConverter {
         .toInstant();
   }
 
-  public static Instant toMonthEndDateTime(Instant yearMonth) {
+  public static Instant toMonthEndAtZone(Instant yearMonth, String zoneId) {
     return yearMonth
-        .atZone(ZoneOffset.UTC)
+        .atZone(ZoneId.of(zoneId))
         .withDayOfMonth(1)
         .plusMonths(1)
         .minusNanos(1)

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -1,10 +1,13 @@
 package com.heartsave.todaktodak_api.diary.controller;
 
+import static com.heartsave.todaktodak_api.common.constant.CoreConstant.HEADER.DEFAULT_TIME_ZONE;
+import static com.heartsave.todaktodak_api.common.constant.CoreConstant.HEADER.TIME_ZONE_KEY;
+
 import com.heartsave.todaktodak_api.auth.annotation.TodakUserId;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
-import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryWriteResponse;
+import com.heartsave.todaktodak_api.diary.dto.response.DiaryYearMonthResponse;
 import com.heartsave.todaktodak_api.diary.service.DiaryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -49,7 +52,7 @@ public class DiaryController {
   public ResponseEntity<DiaryWriteResponse> writeDiary(
       @TodakUserId Long memberId,
       @Valid @RequestBody DiaryWriteRequest writeRequest,
-      @RequestHeader(name = "Todak-Time-Zone", defaultValue = "UTC") String zoneName) {
+      @RequestHeader(name = TIME_ZONE_KEY, defaultValue = DEFAULT_TIME_ZONE) String zoneName) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(diaryService.write(memberId, writeRequest, zoneName));
   }
@@ -79,7 +82,7 @@ public class DiaryController {
         @ApiResponse(responseCode = "400", description = "잘못된 요청")
       })
   @GetMapping
-  public ResponseEntity<DiaryIndexResponse> getDiaryIndex(
+  public ResponseEntity<DiaryYearMonthResponse> getDiaryYearMonthInfo(
       @TodakUserId Long memberId,
       @Parameter(
               name = "yearMonth",
@@ -88,8 +91,10 @@ public class DiaryController {
               required = true,
               schema = @Schema(type = "string"))
           @RequestParam("yearMonth")
-          Instant yearMonth) {
-    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getIndex(memberId, yearMonth));
+          Instant request,
+      @RequestHeader(name = TIME_ZONE_KEY, defaultValue = DEFAULT_TIME_ZONE) String zoneName) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(diaryService.getYearMonth(memberId, request, zoneName));
   }
 
   @Operation(summary = "일기 상세 조회")

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,9 +47,11 @@ public class DiaryController {
       })
   @PostMapping
   public ResponseEntity<DiaryWriteResponse> writeDiary(
-      @TodakUserId Long memberId, @Valid @RequestBody DiaryWriteRequest writeRequest) {
+      @TodakUserId Long memberId,
+      @Valid @RequestBody DiaryWriteRequest writeRequest,
+      @RequestHeader(name = "Todak-Time-Zone", defaultValue = "UTC") String zoneName) {
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(diaryService.write(memberId, writeRequest));
+        .body(diaryService.write(memberId, writeRequest, zoneName));
   }
 
   @Operation(summary = "일기 삭제")

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -116,7 +116,7 @@ public class DiaryController {
           @Valid
           @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.")
           @RequestParam("date")
-          Instant requestDate) {
-    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(memberId, requestDate));
+          Instant request) {
+    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(memberId, request));
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/MySharedDiaryController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PastOrPresent;
 import java.time.Instant;
@@ -74,7 +73,6 @@ public class MySharedDiaryController {
               description = "조회할 일기 날짜",
               example = "2024-11-04",
               schema = @Schema(type = "string", format = "Instant"))
-          @Valid
           @PastOrPresent
           @RequestParam("date")
           Instant requestDateTime) {

--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/PublicDiaryController.java
@@ -50,7 +50,6 @@ public class PublicDiaryController {
     log.info("공개 일기를 조회를 요청합니다. after = {}", request.publicDiaryId());
     PublicDiaryPageResponse response = publicDiaryService.getPagination(memberId, request);
     log.info("공개 일기 조회를 성공적으로 마쳤습니다. after = {}", request.publicDiaryId());
-    System.out.println("response = " + response);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/DiaryWriteRequest.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/request/DiaryWriteRequest.java
@@ -27,7 +27,7 @@ public class DiaryWriteRequest {
   @PastOrPresent(message = "Diary Writing Date is Future")
   @NotNull
   @JsonProperty("date")
-  private Instant dateTime;
+  private Instant createdTime;
 
   @Schema(description = "일기에 기록된 감정", example = "happy", required = true)
   @NotNull(message = "DiaryEmotion is Null")

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryYearMonthResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryYearMonthResponse.java
@@ -1,6 +1,7 @@
 package com.heartsave.todaktodak_api.diary.dto.response;
 
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryYearMonthProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -13,7 +14,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(description = "연월 일기 작성 현황 API 응답 객체")
-public class DiaryIndexResponse {
+public class DiaryYearMonthResponse {
   @Schema(description = "일기 연월 작성 현황 목록")
-  private List<DiaryIndexProjection> diaryIndexes;
+  @JsonProperty("diaryIndexes")
+  private List<DiaryYearMonthProjection> diaryYearMonths;
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
@@ -17,6 +17,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
@@ -42,7 +43,13 @@ import org.hibernate.annotations.OnDeleteAction;
     sequenceName = "DIARY_SEQ", // DB name
     initialValue = 1,
     allocationSize = 50)
-@Table(name = "diary")
+@Table(
+    name = "diary",
+    indexes = {
+      @Index(
+          name = "idx_diary_id_diary_created_time",
+          columnList = "id DESC,diary_created_time DESC")
+    })
 public class DiaryEntity extends BaseEntity {
 
   @Id

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/DiaryEntity.java
@@ -97,7 +97,7 @@ public class DiaryEntity extends BaseEntity {
     this.memberEntity = member;
     this.emotion = request.getEmotion();
     this.content = request.getContent();
-    this.diaryCreatedTime = request.getDateTime();
+    this.diaryCreatedTime = request.getCreatedTime();
     this.webtoonImageUrl = DEFAULT_URL;
     this.bgmUrl = DEFAULT_URL;
   }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/PublicDiaryEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/PublicDiaryEntity.java
@@ -42,8 +42,9 @@ import org.hibernate.annotations.OnDeleteAction;
     name = "public_diary",
     indexes = {
       @Index(name = "idx_created_time_public_diary_id", columnList = "created_time DESC, id DESC"),
-      @Index(name = "idx_member_id_public_diary_id", columnList = "member_id DESC, id DESC"),
-      @Index(name = "idx_member_id_created_time", columnList = "member_id DESC, created_time DESC")
+      @Index(
+          name = "idx_member_id_create_time_public_diary_id",
+          columnList = "member_id DESC, created_time DESC, id DESC")
     })
 public class PublicDiaryEntity extends BaseEntity {
 

--- a/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryYearMonthProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/entity/projection/DiaryYearMonthProjection.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
 @Schema(description = "연월 일기 작성 현황 API 응답 데이터")
-public interface DiaryIndexProjection {
+public interface DiaryYearMonthProjection {
 
   @JsonProperty("diaryId")
   Long getId();

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -21,18 +21,9 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
       value = "DELETE FROM DiaryEntity d WHERE :diaryId = d.id and :memberId = d.memberEntity.id")
   int deleteByIds(@Param("memberId") Long memberId, @Param("diaryId") Long diaryId);
 
-  @Query(
-      value =
-          """
-            SELECT d.id as id, d.diaryCreatedTime as diaryCreatedTime
-            FROM DiaryEntity d
-            WHERE d.memberEntity.id = :memberId AND d.diaryCreatedTime BETWEEN :startTime AND :endTime
-            ORDER BY d.diaryCreatedTime ASC
-          """)
-  Optional<List<DiaryYearMonthProjection>> findYearMonthsByMemberIdAndInstants(
-      @Param("memberId") Long memberId,
-      @Param("startTime") Instant startTime,
-      @Param("endTime") Instant endTime);
+  List<DiaryYearMonthProjection>
+      findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc(
+          Long memberId, Instant startTime, Instant endTime);
 
   Optional<DiaryEntity> findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(
       Long memberId, Instant diaryCreatedTime);

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -4,7 +4,6 @@ import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIdsProjection;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryYearMonthProjection;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,17 +28,14 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
             FROM DiaryEntity d
             WHERE d.memberEntity.id = :memberId AND d.diaryCreatedTime BETWEEN :startTime AND :endTime
             ORDER BY d.diaryCreatedTime ASC
-""")
+          """)
   Optional<List<DiaryYearMonthProjection>> findYearMonthsByMemberIdAndInstants(
       @Param("memberId") Long memberId,
       @Param("startTime") Instant startTime,
       @Param("endTime") Instant endTime);
 
-  @Query(
-      value =
-          " SELECT d FROM DiaryEntity  d WHERE d.memberEntity.id = :memberId AND CAST (d.diaryCreatedTime as DATE) = :diaryDate ")
-  Optional<DiaryEntity> findByMemberIdAndDate(
-      @Param("memberId") Long memberId, @Param("diaryDate") LocalDate diaryDate);
+  Optional<DiaryEntity> findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(
+      Long memberId, Instant diaryCreatedTime);
 
   @Query(
       value =

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -14,12 +14,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
 
-  @Query(
-      value =
-          "SELECT CASE WHEN COUNT(d) > 0 THEN true ELSE false END FROM DiaryEntity d "
-              + "WHERE d.memberEntity.id = :memberId "
-              + "AND  CAST(d.diaryCreatedTime AS LocalDate)  = :diaryDate")
-  boolean existsByDate(@Param("memberId") Long memberId, @Param("diaryDate") LocalDate diaryDate);
+  boolean existsByMemberEntity_IdAndDiaryCreatedTimeBetween(
+      Long memberId, Instant start, Instant end);
 
   @Modifying
   @Query(

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -2,7 +2,7 @@ package com.heartsave.todaktodak_api.diary.repository;
 
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIdsProjection;
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryYearMonthProjection;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -24,11 +24,16 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
 
   @Query(
       value =
-          "SELECT d.id as id, d.diaryCreatedTime as diaryCreatedTime FROM DiaryEntity d WHERE d.memberEntity.id = :memberId AND d.diaryCreatedTime BETWEEN :startDateTime AND :endDateTime ORDER BY d.diaryCreatedTime ASC")
-  Optional<List<DiaryIndexProjection>> findIndexesByMemberIdAndDateTimes(
+          """
+            SELECT d.id as id, d.diaryCreatedTime as diaryCreatedTime
+            FROM DiaryEntity d
+            WHERE d.memberEntity.id = :memberId AND d.diaryCreatedTime BETWEEN :startTime AND :endTime
+            ORDER BY d.diaryCreatedTime ASC
+""")
+  Optional<List<DiaryYearMonthProjection>> findYearMonthsByMemberIdAndInstants(
       @Param("memberId") Long memberId,
-      @Param("startDateTime") Instant startDateTime,
-      @Param("endDateTime") Instant endDateTime);
+      @Param("startTime") Instant startTime,
+      @Param("endTime") Instant endTime);
 
   @Query(
       value =

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
@@ -5,7 +5,7 @@ import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryPageIndexProjection;
 import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryContentProjection;
 import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreviewProjection;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -16,20 +16,20 @@ import org.springframework.data.repository.query.Param;
 public interface MySharedDiaryRepository extends JpaRepository<PublicDiaryEntity, Long> {
 
   Optional<DiaryPageIndexProjection> findFirstByMemberEntity_IdOrderByCreatedTimeDescIdDesc(
-      @Param("memberId") Long memberId);
+      Long memberId);
 
   @Query(
       value =
           """
-                      SELECT
-                       new com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreviewProjection(
-                       pd.id,
-                       d.webtoonImageUrl,
-                       pd.createdTime
-                       )
-                      FROM PublicDiaryEntity pd JOIN pd.diaryEntity d
-                      WHERE pd.memberEntity.id = :memberId AND pd.createdTime <= :#{#index.createdTime} AND pd.id < :#{#index.publicDiaryId}
-                      ORDER BY pd.createdTime DESC, pd.id DESC
+              SELECT
+               new com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreviewProjection(
+               pd.id,
+               d.webtoonImageUrl,
+               pd.createdTime
+               )
+              FROM PublicDiaryEntity pd JOIN pd.diaryEntity d
+              WHERE pd.memberEntity.id = :memberId AND pd.createdTime <= :#{#index.createdTime} AND pd.id < :#{#index.publicDiaryId}
+              ORDER BY pd.createdTime DESC, pd.id DESC
           """)
   List<MySharedDiaryPreviewProjection> findNextPreviews(
       @Param("memberId") Long memberId, @Param("index") DiaryPageIndex index, Pageable pageable);
@@ -46,8 +46,8 @@ public interface MySharedDiaryRepository extends JpaRepository<PublicDiaryEntity
             )
             FROM PublicDiaryEntity pd
             JOIN pd.diaryEntity d
-            WHERE  pd.memberEntity.id = :memberId AND CAST(d.diaryCreatedTime AS LocalDate) = :publicDiaryDate
+            WHERE  pd.memberEntity.id = :memberId AND d.diaryCreatedTime = :publicDiaryDate
             """)
   Optional<MySharedDiaryContentProjection> findContent(
-      @Param("memberId") Long memberId, @Param("publicDiaryDate") LocalDate publicDiaryDate);
+      @Param("memberId") Long memberId, @Param("publicDiaryDate") Instant publicDiaryDate);
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -92,15 +92,14 @@ public class DiaryService {
   }
 
   @Transactional(readOnly = true)
-  public DiaryResponse getDiary(Long memberId, Instant requestDate) {
+  public DiaryResponse getDiary(Long memberId, Instant request) {
     log.info("사용자의 나의 일기 정보를 요청합니다.");
     DiaryEntity diary =
         diaryRepository
-            .findByMemberIdAndDate(memberId, InstantUtils.toLocalDate(requestDate))
+            .findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(memberId, request)
             .orElseThrow(
                 () ->
-                    new DiaryNotFoundException(
-                        DiaryErrorSpec.DIARY_NOT_FOUND, memberId, requestDate));
+                    new DiaryNotFoundException(DiaryErrorSpec.DIARY_NOT_FOUND, memberId, request));
     log.info("사용자의 나의 일기 정보를 성공적으로 가져왔습니다.");
 
     return DiaryResponse.builder()

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -39,7 +39,7 @@ public class DiaryService {
   public DiaryWriteResponse write(Long memberId, DiaryWriteRequest request, String zoneName) {
 
     DiaryEntity diary = createDiaryEntity(memberId, request);
-    validateDailyDiaryLimit(memberId, diary, zoneName);
+    validateDailyDiaryLimit(memberId, request, zoneName);
 
     log.info("AI 컨텐츠 생성 요청을 시작합니다.");
     AiDiaryContentResponse response = aiClientService.callDiaryContent(diary);
@@ -52,8 +52,8 @@ public class DiaryService {
     return DiaryWriteResponse.builder().aiComment(response.getAiComment()).build();
   }
 
-  private void validateDailyDiaryLimit(Long memberId, DiaryEntity diary, String zoneName) {
-    Instant diaryCreatedTime = diary.getDiaryCreatedTime();
+  private void validateDailyDiaryLimit(Long memberId, DiaryWriteRequest request, String zoneName) {
+    Instant diaryCreatedTime = request.getCreatedTime();
     if (diaryRepository.existsByMemberEntity_IdAndDiaryCreatedTimeBetween(
         memberId,
         InstantUtils.toDayStartAtZone(diaryCreatedTime, zoneName),

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/DiaryService.java
@@ -83,9 +83,8 @@ public class DiaryService {
     Instant endTime = InstantUtils.toMonthEndAtZone(request, zoneName);
     log.info("해당 연월에 작성한 일기를 정보를 요청합니다.");
     List<DiaryYearMonthProjection> yearMonthProjection =
-        diaryRepository
-            .findYearMonthsByMemberIdAndInstants(memberId, startTime, endTime)
-            .orElseGet(List::of);
+        diaryRepository.findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc(
+            memberId, startTime, endTime);
 
     log.info("해당 연월에 작성한 일기를 정보를 성공적으로 가져왔습니다.");
     return DiaryYearMonthResponse.builder().diaryYearMonths(yearMonthProjection).build();

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
@@ -1,6 +1,6 @@
 package com.heartsave.todaktodak_api.diary.service;
 
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.common.exception.errorspec.PublicDiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageManager;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
@@ -83,7 +83,7 @@ public class MySharedDiaryService {
     log.info("나의 공개된 일기 content only 를 요청합니다.");
     MySharedDiaryContentOnlyProjection contentOnly =
         mySharedDiaryRepository
-            .findContentOnly(memberId, InstantConverter.toLocalDate(requestDateTime))
+            .findContentOnly(memberId, InstantUtils.toLocalDate(requestDateTime))
             .orElseThrow(
                 () ->
                     new PublicDiaryNotFoundException(

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
@@ -61,7 +61,7 @@ public class MySharedDiaryService {
   @Transactional(readOnly = true)
   public MySharedDiaryResponse getDiary(Long memberId, Instant requestInstant) {
     log.info("나의 공개된 일기 상세 정보를 요청합니다.");
-    MySharedDiaryContentProjection contentOnly = fetchContentOnly(requestInstant, memberId);
+    MySharedDiaryContentProjection contentOnly = fetchContent(requestInstant, memberId);
     replaceWithPreSignedUrls(contentOnly);
 
     DiaryReactionCountProjection reactionCount =
@@ -80,7 +80,7 @@ public class MySharedDiaryService {
         s3FileStorageManager.preSignedBgmUrlFrom(contentProjection.getBgmUrl()));
   }
 
-  private MySharedDiaryContentProjection fetchContentOnly(Instant requestDateTime, Long memberId) {
+  private MySharedDiaryContentProjection fetchContent(Instant requestDateTime, Long memberId) {
     log.info("나의 공개된 일기 content only 를 요청합니다.");
     MySharedDiaryContentProjection contentProjection =
         mySharedDiaryRepository

--- a/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryService.java
@@ -1,6 +1,5 @@
 package com.heartsave.todaktodak_api.diary.service;
 
-import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.common.exception.errorspec.PublicDiaryErrorSpec;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageManager;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
@@ -84,7 +83,7 @@ public class MySharedDiaryService {
     log.info("나의 공개된 일기 content only 를 요청합니다.");
     MySharedDiaryContentProjection contentProjection =
         mySharedDiaryRepository
-            .findContent(memberId, InstantUtils.toLocalDate(requestDateTime))
+            .findContent(memberId, requestDateTime)
             .orElseThrow(
                 () ->
                     new PublicDiaryNotFoundException(

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/controller/AiWebhookControllerTest.java
@@ -13,7 +13,7 @@ import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonComplet
 import com.heartsave.todaktodak_api.ai.webhook.service.AiDiaryService;
 import com.heartsave.todaktodak_api.ai.webhook.service.AiWebhookCharacterService;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.common.exception.errorspec.MemberErrorSpec;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -62,7 +62,7 @@ class AiWebhookControllerTest {
       WebhookWebtoonCompletionRequest request =
           new WebhookWebtoonCompletionRequest(
               member.getId(),
-              InstantConverter.toLocalDate(diary.getDiaryCreatedTime()),
+              InstantUtils.toLocalDate(diary.getDiaryCreatedTime()),
               TEST_WEBTOON_KEY_URL);
 
       doNothing().when(aiDiaryService).saveWebtoon(any(WebhookWebtoonCompletionRequest.class));
@@ -82,9 +82,7 @@ class AiWebhookControllerTest {
     void saveWebtoon_InvalidRequest_Returns400() throws Exception {
       WebhookWebtoonCompletionRequest request =
           new WebhookWebtoonCompletionRequest(
-              null,
-              InstantConverter.toLocalDate(diary.getDiaryCreatedTime()),
-              TEST_WEBTOON_KEY_URL);
+              null, InstantUtils.toLocalDate(diary.getDiaryCreatedTime()), TEST_WEBTOON_KEY_URL);
 
       mockMvc
           .perform(
@@ -108,7 +106,7 @@ class AiWebhookControllerTest {
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
               member.getId(),
-              InstantConverter.toLocalDate(diary.getDiaryCreatedTime()),
+              InstantUtils.toLocalDate(diary.getDiaryCreatedTime()),
               TEST_BGM_KEY_URL);
 
       doNothing().when(aiDiaryService).saveBgm(any(WebhookBgmCompletionRequest.class));
@@ -128,7 +126,7 @@ class AiWebhookControllerTest {
     void saveBgm_InvalidRequest_Returns400() throws Exception {
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              null, InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), TEST_BGM_KEY_URL);
+              null, InstantUtils.toLocalDate(diary.getDiaryCreatedTime()), TEST_BGM_KEY_URL);
 
       mockMvc
           .perform(
@@ -146,7 +144,7 @@ class AiWebhookControllerTest {
     void saveBgm_EmptyBgmUrl_Returns400() throws Exception {
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), "");
+              member.getId(), InstantUtils.toLocalDate(diary.getDiaryCreatedTime()), "");
 
       mockMvc
           .perform(

--- a/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/ai/webhook/repository/AiRepositoryTest.java
@@ -10,7 +10,7 @@ import com.heartsave.todaktodak_api.ai.webhook.domain.WebhookWebtoonCompletion;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookBgmCompletionRequest;
 import com.heartsave.todaktodak_api.ai.webhook.dto.request.WebhookWebtoonCompletionRequest;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
@@ -62,7 +62,7 @@ class AiRepositoryTest {
       String newUrl = "https://new-url/webtoon.jpg";
       WebhookWebtoonCompletionRequest request =
           new WebhookWebtoonCompletionRequest(
-              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), newUrl);
+              member.getId(), InstantUtils.toLocalDate(diary.getDiaryCreatedTime()), newUrl);
       WebhookWebtoonCompletion completion = WebhookWebtoonCompletion.from(request, newUrl);
       aiRepository.updateWebtoonUrl(completion);
 
@@ -96,7 +96,7 @@ class AiRepositoryTest {
       String newBgmUrl = "/music-ai/1/2024/11/06/bgm.mp3";
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), newBgmUrl);
+              member.getId(), InstantUtils.toLocalDate(diary.getDiaryCreatedTime()), newBgmUrl);
       WebhookBgmCompletion completion = WebhookBgmCompletion.from(request, newBgmUrl);
 
       aiRepository.updateBgmUrl(completion);
@@ -143,7 +143,7 @@ class AiRepositoryTest {
       String newBgmUrl = "https://new-url/target-member-bgm.mp3";
       WebhookBgmCompletionRequest request =
           new WebhookBgmCompletionRequest(
-              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()), newBgmUrl);
+              member.getId(), InstantUtils.toLocalDate(diary.getDiaryCreatedTime()), newBgmUrl);
       WebhookBgmCompletion completion = WebhookBgmCompletion.from(request, newBgmUrl);
 
       aiRepository.updateBgmUrl(completion);
@@ -165,7 +165,7 @@ class AiRepositoryTest {
     void returnsFalseWhenBothUrlsAreEmpty() {
       Boolean result =
           aiRepository.isContentCompleted(
-              member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()));
+              member.getId(), InstantUtils.toLocalDate(diary.getDiaryCreatedTime()));
 
       assertThat(result).isFalse();
     }
@@ -188,8 +188,7 @@ class AiRepositoryTest {
       tem.clear();
 
       Boolean result =
-          aiRepository.isContentCompleted(
-              member.getId(), InstantConverter.toLocalDate(nowDateTime));
+          aiRepository.isContentCompleted(member.getId(), InstantUtils.toLocalDate(nowDateTime));
 
       assertThat(result).isFalse();
     }
@@ -212,8 +211,7 @@ class AiRepositoryTest {
       tem.clear();
 
       Boolean result =
-          aiRepository.isContentCompleted(
-              member.getId(), InstantConverter.toLocalDate(nowDateTime));
+          aiRepository.isContentCompleted(member.getId(), InstantUtils.toLocalDate(nowDateTime));
 
       assertThat(result).isFalse();
     }
@@ -238,7 +236,7 @@ class AiRepositoryTest {
 
       Boolean result =
           aiRepository.isContentCompleted(
-              member.getId(), InstantConverter.toLocalDate(completedDiary.getDiaryCreatedTime()));
+              member.getId(), InstantUtils.toLocalDate(completedDiary.getDiaryCreatedTime()));
 
       assertThat(result).isTrue();
     }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/common/TestDiaryObjectFactory.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/common/TestDiaryObjectFactory.java
@@ -1,16 +1,16 @@
 package com.heartsave.todaktodak_api.diary.common;
 
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryYearMonthProjection;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 
 public class TestDiaryObjectFactory {
-  public static List<DiaryIndexProjection> getTestDiaryIndexProjections_2024_03_Data_Of_2() {
-    List<DiaryIndexProjection> mockIndexes =
+  public static List<DiaryYearMonthProjection> getTestDiaryIndexProjections_2024_03_Data_Of_2() {
+    List<DiaryYearMonthProjection> mockIndexes =
         List.of(
-            new DiaryIndexProjection() {
+            new DiaryYearMonthProjection() {
               @Override
               public Long getId() {
                 return 1L;
@@ -21,7 +21,7 @@ public class TestDiaryObjectFactory {
                 return LocalDateTime.of(2024, 3, 15, 14, 30).atZone(ZoneId.of("UTC")).toInstant();
               }
             },
-            new DiaryIndexProjection() {
+            new DiaryYearMonthProjection() {
               @Override
               public Long getId() {
                 return 2L;

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
@@ -1,6 +1,5 @@
 package com.heartsave.todaktodak_api.diary.controller;
 
-import static com.heartsave.todaktodak_api.diary.common.TestDiaryObjectFactory.getTestDiaryIndexProjections_2024_03_Data_Of_2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -18,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.security.WithMockTodakUser;
+import com.heartsave.todaktodak_api.diary.common.TestDiaryObjectFactory;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryResponse;
@@ -113,7 +113,8 @@ public class DiaryControllerTest {
   @Test
   void getManyOfDiaryYearMonthSuccess() throws Exception {
     // response
-    List<DiaryYearMonthProjection> mockIndexes = getTestDiaryIndexProjections_2024_03_Data_Of_2();
+    List<DiaryYearMonthProjection> mockIndexes =
+        TestDiaryObjectFactory.getTestDiaryIndexProjections_2024_03_Data_Of_2();
     DiaryYearMonthResponse mockResponse =
         DiaryYearMonthResponse.builder().diaryYearMonths(mockIndexes).build();
     String yearMonth = "2024-03-01T09:12:30.123Z";

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
@@ -4,6 +4,7 @@ import static com.heartsave.todaktodak_api.diary.common.TestDiaryObjectFactory.g
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,10 +20,10 @@ import com.heartsave.todaktodak_api.common.BaseTestObject;
 import com.heartsave.todaktodak_api.common.security.WithMockTodakUser;
 import com.heartsave.todaktodak_api.diary.constant.DiaryEmotion;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryWriteRequest;
-import com.heartsave.todaktodak_api.diary.dto.response.DiaryIndexResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryResponse;
 import com.heartsave.todaktodak_api.diary.dto.response.DiaryWriteResponse;
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.heartsave.todaktodak_api.diary.dto.response.DiaryYearMonthResponse;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryYearMonthProjection;
 import com.heartsave.todaktodak_api.diary.service.DiaryService;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -60,7 +61,7 @@ public class DiaryControllerTest {
 
     final String AI_COMMENT = "this is test ai comment";
 
-    when(diaryService.write(anyLong(), any(DiaryWriteRequest.class)))
+    when(diaryService.write(anyLong(), any(DiaryWriteRequest.class), anyString()))
         .thenReturn(DiaryWriteResponse.builder().aiComment(AI_COMMENT).build());
     MvcResult mvcResult =
         mockMvc
@@ -72,7 +73,7 @@ public class DiaryControllerTest {
             .andDo(print())
             .andReturn();
 
-    verify(diaryService, times(1)).write(anyLong(), any(DiaryWriteRequest.class));
+    verify(diaryService, times(1)).write(anyLong(), any(DiaryWriteRequest.class), anyString());
     MockHttpServletResponse response = mvcResult.getResponse();
     assertThat(response.getContentAsString()).contains(AI_COMMENT);
   }
@@ -112,13 +113,14 @@ public class DiaryControllerTest {
   @Test
   void getManyOfDiaryYearMonthSuccess() throws Exception {
     // response
-    List<DiaryIndexProjection> mockIndexes = getTestDiaryIndexProjections_2024_03_Data_Of_2();
-    DiaryIndexResponse mockResponse =
-        DiaryIndexResponse.builder().diaryIndexes(mockIndexes).build();
+    List<DiaryYearMonthProjection> mockIndexes = getTestDiaryIndexProjections_2024_03_Data_Of_2();
+    DiaryYearMonthResponse mockResponse =
+        DiaryYearMonthResponse.builder().diaryYearMonths(mockIndexes).build();
     String yearMonth = "2024-03-01T09:12:30.123Z";
 
     // when
-    when(diaryService.getIndex(anyLong(), any(Instant.class))).thenReturn(mockResponse);
+    when(diaryService.getYearMonth(anyLong(), any(Instant.class), anyString()))
+        .thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult = null;
@@ -134,11 +136,11 @@ public class DiaryControllerTest {
 
     assertThat(contentAsString)
         .as("설정된 diary index와 응답 index가 서로 다릅니다.")
-        .contains(objectMapper.writeValueAsString(mockResponse.getDiaryIndexes().get(0)));
+        .contains(objectMapper.writeValueAsString(mockResponse.getDiaryYearMonths().get(0)));
 
     assertThat(contentAsString)
         .as("설정된 diary index와 응답 index가 서로 다릅니다.")
-        .contains(objectMapper.writeValueAsString(mockResponse.getDiaryIndexes().get(1)));
+        .contains(objectMapper.writeValueAsString(mockResponse.getDiaryYearMonths().get(1)));
   }
 
   @DisplayName("연월 일기 작성 현황 0건 성공")
@@ -146,11 +148,12 @@ public class DiaryControllerTest {
   @Test
   void getZeroOfDiaryYearMonthSuccess() throws Exception {
     // response
-    DiaryIndexResponse mockResponse = new DiaryIndexResponse(new ArrayList<>());
+    DiaryYearMonthResponse mockResponse = new DiaryYearMonthResponse(new ArrayList<>());
     String yearMonth = "2024-01-01T00:00:00.010Z";
 
     // when
-    when(diaryService.getIndex(anyLong(), any(Instant.class))).thenReturn(mockResponse);
+    when(diaryService.getYearMonth(anyLong(), any(Instant.class), anyString()))
+        .thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult =

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -111,9 +111,8 @@ public class DiaryRepositoryTest {
         InstantUtils.toMonthEndAtZone(diary1.getDiaryCreatedTime(), DEFAULT_TIME_ZONE);
 
     List<DiaryYearMonthProjection> resultIndex =
-        diaryRepository
-            .findYearMonthsByMemberIdAndInstants(member.getId(), testStart, testEnd)
-            .orElseGet(List::of);
+        diaryRepository.findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc(
+            member.getId(), testStart, testEnd);
     assertThat(resultIndex).as("메서드 응답이 null 입니다.").isNotNull();
 
     DiaryYearMonthProjection first = resultIndex.get(0);
@@ -154,9 +153,8 @@ public class DiaryRepositoryTest {
             .toInstant(ZoneOffset.UTC);
 
     List<DiaryYearMonthProjection> resultIndex =
-        diaryRepository
-            .findYearMonthsByMemberIdAndInstants(member.getId(), testStart, testEnd)
-            .orElseGet(List::of);
+        diaryRepository.findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc(
+            member.getId(), testStart, testEnd);
     assertThat(resultIndex).as("메서드 응답이 null 입니다.").isNotNull();
 
     assertThat(resultIndex.isEmpty()).as("메서드 응답 내부가 비어있지 않습니다.").isTrue();

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -12,12 +12,12 @@ import com.heartsave.todaktodak_api.diary.entity.projection.DiaryYearMonthProjec
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -165,9 +165,11 @@ public class DiaryRepositoryTest {
   @Test
   @DisplayName("findByMemberIdAndDate - 일기를 성공적으로 조회")
   void findByMemberIdAndDateSuccess() {
-    LocalDate diaryDate = InstantUtils.toLocalDate(diary.getDiaryCreatedTime());
+    Instant diaryDate = diary.getDiaryCreatedTime();
 
-    Optional<DiaryEntity> result = diaryRepository.findByMemberIdAndDate(member.getId(), diaryDate);
+    Optional<DiaryEntity> result =
+        diaryRepository.findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(
+            member.getId(), diaryDate);
 
     assertThat(result).as("해당 날짜(%s)에 작성된 일기를 찾을 수 없습니다.", diaryDate).isPresent();
     assertThat(result.get().getId())
@@ -190,10 +192,11 @@ public class DiaryRepositoryTest {
   @Test
   @DisplayName("findByMemberIdAndDate - 해당 날짜에 일기가 없는 경우")
   void findByMemberIdAndDateEmpty() {
-    LocalDate differentDate = InstantUtils.toLocalDate(diary.getDiaryCreatedTime()).plusDays(-1);
+    Instant differentDate = diary.getDiaryCreatedTime().minus(1L, ChronoUnit.DAYS);
 
     Optional<DiaryEntity> result =
-        diaryRepository.findByMemberIdAndDate(member.getId(), differentDate);
+        diaryRepository.findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(
+            member.getId(), differentDate);
 
     assertThat(result).as("존재하지 않아야 할 날짜(%s)에 일기가 조회되었습니다.", differentDate).isEmpty();
   }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -1,19 +1,22 @@
 package com.heartsave.todaktodak_api.diary.repository;
 
+import static com.heartsave.todaktodak_api.common.constant.CoreConstant.HEADER.DEFAULT_TIME_ZONE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.heartsave.todaktodak_api.common.BaseTestObject;
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIdsProjection;
-import com.heartsave.todaktodak_api.diary.entity.projection.DiaryIndexProjection;
+import com.heartsave.todaktodak_api.diary.entity.projection.DiaryYearMonthProjection;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import com.heartsave.todaktodak_api.member.repository.MemberRepository;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
@@ -51,17 +54,25 @@ public class DiaryRepositoryTest {
   @Test
   @DisplayName("특정 날짜에 해당되는 사용자 일기 없음.")
   void notExistDiaryByDateAndMember() {
-    LocalDate testTime = LocalDate.of(2025, 10, 2);
-    boolean exist = diaryRepository.existsByDate(member.getId(), testTime);
+    Instant testTime =
+        LocalDateTime.now().plusDays(99L).atZone(ZoneId.of(DEFAULT_TIME_ZONE)).toInstant();
+    Instant testStart = InstantUtils.toDayStartAtZone(testTime, DEFAULT_TIME_ZONE);
+    Instant testEnd = InstantUtils.toDayEndAtZone(testTime, DEFAULT_TIME_ZONE);
+    boolean exist =
+        diaryRepository.existsByMemberEntity_IdAndDiaryCreatedTimeBetween(
+            member.getId(), testStart, testEnd);
     assertThat(exist).as("memberID와 날짜에 해당하는 일기가 있습니다.").isFalse();
   }
 
   @Test
   @DisplayName("특정 날짜에 해당되는 사용자 일기가 있음.")
   void existDiaryByDateAndMember() {
+    Instant startTime =
+        InstantUtils.toDayStartAtZone(diary.getDiaryCreatedTime(), DEFAULT_TIME_ZONE);
+    Instant endTime = InstantUtils.toDayEndAtZone(diary.getDiaryCreatedTime(), DEFAULT_TIME_ZONE);
     boolean exist =
-        diaryRepository.existsByDate(
-            member.getId(), InstantConverter.toLocalDate(diary.getDiaryCreatedTime()));
+        diaryRepository.existsByMemberEntity_IdAndDiaryCreatedTimeBetween(
+            member.getId(), startTime, endTime);
     assertThat(exist).as("memberID와 날짜에 해당하는 일기가 없습니다.").isTrue();
   }
 
@@ -94,18 +105,20 @@ public class DiaryRepositoryTest {
     diaryRepository.save(diary1);
     diaryRepository.save(diary2);
 
-    Instant testStart = InstantConverter.toMonthStartDateTime(diary1.getDiaryCreatedTime());
-    Instant testEnd = InstantConverter.toMonthEndDateTime(diary1.getDiaryCreatedTime());
+    Instant testStart =
+        InstantUtils.toMonthStartAtZone(diary1.getDiaryCreatedTime(), DEFAULT_TIME_ZONE);
+    Instant testEnd =
+        InstantUtils.toMonthEndAtZone(diary1.getDiaryCreatedTime(), DEFAULT_TIME_ZONE);
 
-    List<DiaryIndexProjection> resultIndex =
+    List<DiaryYearMonthProjection> resultIndex =
         diaryRepository
-            .findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd)
+            .findYearMonthsByMemberIdAndInstants(member.getId(), testStart, testEnd)
             .orElseGet(List::of);
     assertThat(resultIndex).as("메서드 응답이 null 입니다.").isNotNull();
 
-    DiaryIndexProjection first = resultIndex.get(0);
+    DiaryYearMonthProjection first = resultIndex.get(0);
     assertThat(first).as("first 인덱스 결과가 null 입니다.").isNotNull();
-    DiaryIndexProjection second = resultIndex.get(1);
+    DiaryYearMonthProjection second = resultIndex.get(1);
     assertThat(second).as("second 인덱스 결과가 null 입니다.").isNotNull();
 
     assertThat(first.getId()).as("Diary1 ID와 응답 Diary ID가 서로 다릅니다.").isEqualTo(diary1.getId());
@@ -140,9 +153,9 @@ public class DiaryRepositoryTest {
             .atTime(LocalTime.MAX)
             .toInstant(ZoneOffset.UTC);
 
-    List<DiaryIndexProjection> resultIndex =
+    List<DiaryYearMonthProjection> resultIndex =
         diaryRepository
-            .findIndexesByMemberIdAndDateTimes(member.getId(), testStart, testEnd)
+            .findYearMonthsByMemberIdAndInstants(member.getId(), testStart, testEnd)
             .orElseGet(List::of);
     assertThat(resultIndex).as("메서드 응답이 null 입니다.").isNotNull();
 
@@ -152,7 +165,7 @@ public class DiaryRepositoryTest {
   @Test
   @DisplayName("findByMemberIdAndDate - 일기를 성공적으로 조회")
   void findByMemberIdAndDateSuccess() {
-    LocalDate diaryDate = InstantConverter.toLocalDate(diary.getDiaryCreatedTime());
+    LocalDate diaryDate = InstantUtils.toLocalDate(diary.getDiaryCreatedTime());
 
     Optional<DiaryEntity> result = diaryRepository.findByMemberIdAndDate(member.getId(), diaryDate);
 
@@ -177,8 +190,7 @@ public class DiaryRepositoryTest {
   @Test
   @DisplayName("findByMemberIdAndDate - 해당 날짜에 일기가 없는 경우")
   void findByMemberIdAndDateEmpty() {
-    LocalDate differentDate =
-        InstantConverter.toLocalDate(diary.getDiaryCreatedTime()).plusDays(-1);
+    LocalDate differentDate = InstantUtils.toLocalDate(diary.getDiaryCreatedTime()).plusDays(-1);
 
     Optional<DiaryEntity> result =
         diaryRepository.findByMemberIdAndDate(member.getId(), differentDate);

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
@@ -3,7 +3,6 @@ package com.heartsave.todaktodak_api.diary.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.heartsave.todaktodak_api.common.BaseTestObject;
-import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.diary.domain.DiaryPageIndex;
 import com.heartsave.todaktodak_api.diary.dto.request.DiaryPageRequest;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
@@ -14,7 +13,6 @@ import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryPreview
 import com.heartsave.todaktodak_api.diary.factory.DiaryPageIndexFactory;
 import com.heartsave.todaktodak_api.member.entity.MemberEntity;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -190,8 +188,7 @@ class MySharedDiaryRepositoryTest {
     PublicDiaryEntity expected = publicDiaries.get(3);
     Long memberId = expected.getMemberEntity().getId();
     DiaryEntity diaryEntity = expected.getDiaryEntity();
-    LocalDate requestDate =
-        InstantUtils.toLocalDate(expected.getDiaryEntity().getDiaryCreatedTime());
+    Instant requestDate = expected.getDiaryEntity().getDiaryCreatedTime();
 
     Optional<MySharedDiaryContentProjection> Optional_actual =
         mySharedDiaryRepository.findContent(memberId, requestDate);
@@ -224,14 +221,15 @@ class MySharedDiaryRepositoryTest {
   @Test
   @DisplayName("존재하지 않는 날짜의 공유된 일기를 조회하면 빈 Optional을 반환한다")
   void findContentOnly_ReturnEmpty_WhenNotFound() {
-    LocalDate nonExistentDate = LocalDate.of(3024, 1, 1);
+    Instant nonExistentDate = Instant.now().plus(10L, ChronoUnit.DAYS);
     Long memberId = member.getId();
 
     Optional<MySharedDiaryContentProjection> result =
         mySharedDiaryRepository.findContent(memberId, nonExistentDate);
     assertThat(result).as("존재하지 않는 날짜로 일기 조회 시 빈 Optional이 반환되어야 합니다").isEmpty();
 
-    result = mySharedDiaryRepository.findContent(1000L, LocalDate.now());
+    result =
+        mySharedDiaryRepository.findContent(1000L, Instant.now().truncatedTo(ChronoUnit.MILLIS));
     assertThat(result).as("존재하지 않는 memberId로 일기 조회 시 빈 Optional이 반환되어야 합니다").isEmpty();
   }
 

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
@@ -3,7 +3,7 @@ package com.heartsave.todaktodak_api.diary.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.heartsave.todaktodak_api.common.BaseTestObject;
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.diary.entity.DiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.PublicDiaryEntity;
 import com.heartsave.todaktodak_api.diary.entity.projection.MySharedDiaryContentOnlyProjection;
@@ -162,7 +162,7 @@ class MySharedDiaryRepositoryTest {
     PublicDiaryEntity expected = publicDiaries.get(3);
     Long memberId = expected.getMemberEntity().getId();
     LocalDate requestDate =
-        InstantConverter.toLocalDate(expected.getDiaryEntity().getDiaryCreatedTime());
+        InstantUtils.toLocalDate(expected.getDiaryEntity().getDiaryCreatedTime());
     System.out.println(
         "expected.getDiaryEntity().getDiaryCreatedTime() = "
             + expected.getDiaryEntity().getDiaryCreatedTime());
@@ -194,7 +194,6 @@ class MySharedDiaryRepositoryTest {
                 .getDiaryEntity()
                 .getDiaryCreatedTime()
                 .truncatedTo(ChronoUnit.SECONDS)); // DB에 Instant 저장시 MILLIS 반올림, 따라서 Second 까지 검사
-
   }
 
   @Test

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/DiaryServiceTest.java
@@ -176,9 +176,10 @@ public class DiaryServiceTest {
     Instant requestYearMonth =
         LocalDate.of(testYear, testMonth, 1).atStartOfDay(ZoneId.of(DEFAULT_TIME_ZONE)).toInstant();
 
-    when(mockDiaryRepository.findYearMonthsByMemberIdAndInstants(
-            member.getId(), testStart, testEnd))
-        .thenReturn(Optional.of(testProjection));
+    when(mockDiaryRepository
+            .findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc(
+                member.getId(), testStart, testEnd))
+        .thenReturn(testProjection);
     DiaryYearMonthResponse response =
         diaryService.getYearMonth(member.getId(), requestYearMonth, DEFAULT_TIME_ZONE);
 
@@ -221,9 +222,10 @@ public class DiaryServiceTest {
             .toInstant();
     Instant requestYearMonth =
         LocalDate.of(testYear, testMonth, 1).atStartOfDay(ZoneId.of(DEFAULT_TIME_ZONE)).toInstant();
-    when(mockDiaryRepository.findYearMonthsByMemberIdAndInstants(
-            member.getId(), testStart, testEnd))
-        .thenReturn(Optional.empty());
+    when(mockDiaryRepository
+            .findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc(
+                member.getId(), testStart, testEnd))
+        .thenReturn(List.of());
 
     DiaryYearMonthResponse yearMonths =
         diaryService.getYearMonth(member.getId(), requestYearMonth, DEFAULT_TIME_ZONE);

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.heartsave.todaktodak_api.common.converter.InstantConverter;
+import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.common.security.domain.TodakUser;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageManager;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
@@ -138,8 +138,7 @@ public class MySharedDiaryServiceTest {
     when(contentOnly.getWebtoonImageUrls()).thenReturn(List.of(webtoonUrl));
     when(contentOnly.getBgmUrl()).thenReturn(bgmUrl);
 
-    when(mySharedDiaryRepository.findContentOnly(
-            memberId, InstantConverter.toLocalDate(requestDate)))
+    when(mySharedDiaryRepository.findContentOnly(memberId, InstantUtils.toLocalDate(requestDate)))
         .thenReturn(Optional.of(contentOnly));
     when(reactionRepository.countEachByDiaryId(diaryId)).thenReturn(reactionCount);
     when(reactionRepository.findMemberReaction(memberId, diaryId)).thenReturn(memberReactions);
@@ -167,8 +166,7 @@ public class MySharedDiaryServiceTest {
   void getDiary_ThrowsException_WhenDiaryNotFound() {
     // Given
     Instant requestDate = Instant.now();
-    when(mySharedDiaryRepository.findContentOnly(
-            memberId, InstantConverter.toLocalDate(requestDate)))
+    when(mySharedDiaryRepository.findContentOnly(memberId, InstantUtils.toLocalDate(requestDate)))
         .thenReturn(Optional.empty());
 
     // When & Then

--- a/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/service/MySharedDiaryServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.heartsave.todaktodak_api.common.BaseTestObject;
-import com.heartsave.todaktodak_api.common.converter.InstantUtils;
 import com.heartsave.todaktodak_api.common.storage.s3.S3FileStorageManager;
 import com.heartsave.todaktodak_api.diary.constant.DiaryReactionType;
 import com.heartsave.todaktodak_api.diary.domain.DiaryPageIndex;
@@ -156,7 +155,7 @@ public class MySharedDiaryServiceTest {
     when(contentOnly.getWebtoonImageUrls()).thenReturn(List.of(webtoonUrl));
     when(contentOnly.getBgmUrl()).thenReturn(bgmUrl);
 
-    when(mySharedDiaryRepository.findContent(member.getId(), InstantUtils.toLocalDate(requestDate)))
+    when(mySharedDiaryRepository.findContent(member.getId(), requestDate))
         .thenReturn(Optional.of(contentOnly));
     when(reactionRepository.countEachByDiaryId(diaryId)).thenReturn(reactionCount);
     when(reactionRepository.findMemberReaction(member.getId(), diaryId))
@@ -185,7 +184,7 @@ public class MySharedDiaryServiceTest {
   void getDiary_ThrowsException_WhenDiaryNotFound() {
     // Given
     Instant requestDate = Instant.now();
-    when(mySharedDiaryRepository.findContent(member.getId(), InstantUtils.toLocalDate(requestDate)))
+    when(mySharedDiaryRepository.findContent(member.getId(), requestDate))
         .thenReturn(Optional.empty());
 
     // When & Then


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항
- Controller에서 Instant로 시간 정보를 받고 있었지만, 사용자의 디바이스 시간 정보가 다양할 수 있기에 TimeZone 정보를 추가로 받아 클라이언트 시간 기준으로 일기 정보를 조회하는 로직으로 변경하였습니다.

1. 일기 작성시 해당 날짜 일기가 이미 존재하는지 확인
  -  Between 쿼리를 사용하여 해당 날짜의 일기가 존재하는지 사용자 디바이스 시간 기준으로 체크합니다.
  > DiayService의 ```validateDailyDiaryLimit```

---

2. 연월 일기 작성 현화 조회
    -  쿼리 메서드로 변경합니다.
    - Optional<List<>>를 List<>로 변경합니다. 쿼리의 결과가 없는 경우 null이 아닌, 비어있는 List가 나오기에 NPE에 안전합니다.
    > DiaryRepository 의 ```findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc```

---

3. 특정 날짜(연월일) 일기 조회
  - Controller에서 UTC로 받은 날짜를 그대로 사용하여 DB의 시간과 비교한 뒤, 응답합니다.
  - 클라이언트의 TimeZone 정보가 필요 없습니다.
  - 이전과 동일한 로직이기에 변경사항 없습니다.
---

4. 무한 스크롤(공개/나의) 요청
  - TODAK - 260 에서 진행하였습니다.

---
 
5. 나의 공개 일기 클릭시
 - Controller에서 UTC로 받은 날짜를 그대로 사용하여 DB의 시간과 비교한 뒤, 응답합니다.
 -  통일성을 위해 LocalDate가 아닌, Instant기반으로 데이터 조회
  > MySharedDiaryService의 ```fetchContent```

---

## 리뷰 받고 싶은 내용

- 헷갈리시거나 궁금하신 부분 있다면 알려주세요!

## 테스트 및 결과
- 로컬 테스트 확인 완료

## 관련 스크린샷 및 참고자료 (Optional)

close #126 