### PR TITLE
Feature/todak 281/utc logic modify

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/controller/DiaryController.java
@@ -116,7 +116,9 @@ public class DiaryController {
           @Valid
           @PastOrPresent(message = "현재 날짜 이전의 일기만 조회가 가능합니다.")
           @RequestParam("date")
-          Instant request) {
-    return ResponseEntity.status(HttpStatus.OK).body(diaryService.getDiary(memberId, request));
+          Instant request,
+      @RequestHeader(name = TIME_ZONE_KEY, defaultValue = DEFAULT_TIME_ZONE) String zoneName) {
+    DiaryResponse diary = diaryService.getDiary(memberId, request, zoneName);
+    return ResponseEntity.status(HttpStatus.OK).body(diary);
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/dto/response/DiaryResponse.java
@@ -37,5 +37,5 @@ public class DiaryResponse {
 
   @Schema(description = "일기 작성 날짜", example = "2024-10-26", type = "string", format = "date")
   @JsonFormat(pattern = TIME_FORMAT.ISO_DATETIME_WITH_MILLISECONDS, timezone = "UTC")
-  private Instant dateTime;
+  private Instant date;
 }

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepository.java
@@ -25,8 +25,8 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
       findByMemberEntity_IdAndDiaryCreatedTimeBetweenOrderByDiaryCreatedTimeDesc(
           Long memberId, Instant startTime, Instant endTime);
 
-  Optional<DiaryEntity> findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(
-      Long memberId, Instant diaryCreatedTime);
+  Optional<DiaryEntity> findDiaryEntityByMemberEntity_IdAndDiaryCreatedTimeBetween(
+      Long memberId, Instant startTime, Instant endTime);
 
   @Query(
       value =

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
@@ -46,7 +46,7 @@ public interface MySharedDiaryRepository extends JpaRepository<PublicDiaryEntity
             )
             FROM PublicDiaryEntity pd
             JOIN pd.diaryEntity d
-            WHERE  pd.memberEntity.id = :memberId AND d.diaryCreatedTime = :publicDiaryDate
+            WHERE  pd.memberEntity.id = :memberId AND pd.createdTime = :publicDiaryDate
             """)
   Optional<MySharedDiaryContentProjection> findContent(
       @Param("memberId") Long memberId, @Param("publicDiaryDate") Instant publicDiaryDate);

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepository.java
@@ -28,7 +28,9 @@ public interface MySharedDiaryRepository extends JpaRepository<PublicDiaryEntity
                pd.createdTime
                )
               FROM PublicDiaryEntity pd JOIN pd.diaryEntity d
-              WHERE pd.memberEntity.id = :memberId AND pd.createdTime <= :#{#index.createdTime} AND pd.id < :#{#index.publicDiaryId}
+              WHERE pd.memberEntity.id = :memberId AND
+                ((pd.createdTime = :#{#index.createdTime} AND pd.id < :#{#index.publicDiaryId})
+                OR (pd.createdTime < :#{#index.createdTime}))
               ORDER BY pd.createdTime DESC, pd.id DESC
           """)
   List<MySharedDiaryPreviewProjection> findNextPreviews(

--- a/src/main/java/com/heartsave/todaktodak_api/diary/repository/PublicDiaryRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/diary/repository/PublicDiaryRepository.java
@@ -25,12 +25,13 @@ public interface PublicDiaryRepository extends JpaRepository<PublicDiaryEntity, 
             pd.publicContent,
             d.webtoonImageUrl,
             d.bgmUrl,
-            d.diaryCreatedTime
+            pd.createdTime
         )
         FROM PublicDiaryEntity pd
         JOIN pd.diaryEntity d
         JOIN pd.memberEntity m
-        WHERE pd.createdTime <= :#{#index.createdTime} AND pd.id < :#{#index.publicDiaryId}
+        WHERE (pd.createdTime = :#{#index.createdTime} AND pd.id < :#{#index.publicDiaryId})
+        OR (pd.createdTime < :#{#index.createdTime})
         ORDER BY pd.createdTime DESC, pd.id DESC
         """)
   List<PublicDiaryContentProjection> findNextContents(

--- a/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/controller/DiaryControllerTest.java
@@ -178,11 +178,12 @@ public class DiaryControllerTest {
         DiaryResponse.builder()
             .content("테스트 일기 내용")
             .emotion(DiaryEmotion.HAPPY)
-            .dateTime(validDate)
+            .date(validDate)
             .build();
 
     // when
-    when(diaryService.getDiary(anyLong(), any(Instant.class))).thenReturn(mockResponse);
+    when(diaryService.getDiary(anyLong(), any(Instant.class), any(String.class)))
+        .thenReturn(mockResponse);
 
     // then
     MvcResult mvcResult =

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/DiaryRepositoryTest.java
@@ -104,6 +104,7 @@ public class DiaryRepositoryTest {
     DiaryEntity diary2 = BaseTestObject.createDiaryNoIdWithMember(member);
     diaryRepository.save(diary1);
     diaryRepository.save(diary2);
+    System.out.println("diary1.getDiaryCreatedTime() = " + diary1.getDiaryCreatedTime());
 
     Instant testStart =
         InstantUtils.toMonthStartAtZone(diary1.getDiaryCreatedTime(), DEFAULT_TIME_ZONE);
@@ -166,8 +167,10 @@ public class DiaryRepositoryTest {
     Instant diaryDate = diary.getDiaryCreatedTime();
 
     Optional<DiaryEntity> result =
-        diaryRepository.findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(
-            member.getId(), diaryDate);
+        diaryRepository.findDiaryEntityByMemberEntity_IdAndDiaryCreatedTimeBetween(
+            member.getId(),
+            InstantUtils.toDayStartAtZone(diaryDate, DEFAULT_TIME_ZONE),
+            InstantUtils.toDayEndAtZone(diaryDate, DEFAULT_TIME_ZONE));
 
     assertThat(result).as("해당 날짜(%s)에 작성된 일기를 찾을 수 없습니다.", diaryDate).isPresent();
     assertThat(result.get().getId())
@@ -193,8 +196,10 @@ public class DiaryRepositoryTest {
     Instant differentDate = diary.getDiaryCreatedTime().minus(1L, ChronoUnit.DAYS);
 
     Optional<DiaryEntity> result =
-        diaryRepository.findDiaryEntityByMemberEntity_IdAndDiaryCreatedTime(
-            member.getId(), differentDate);
+        diaryRepository.findDiaryEntityByMemberEntity_IdAndDiaryCreatedTimeBetween(
+            member.getId(),
+            InstantUtils.toDayStartAtZone(differentDate, DEFAULT_TIME_ZONE),
+            InstantUtils.toDayEndAtZone(differentDate, DEFAULT_TIME_ZONE));
 
     assertThat(result).as("존재하지 않아야 할 날짜(%s)에 일기가 조회되었습니다.", differentDate).isEmpty();
   }

--- a/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/diary/repository/MySharedDiaryRepositoryTest.java
@@ -47,7 +47,7 @@ class MySharedDiaryRepositoryTest {
   private Long TEST_PUBLIC_DIARY_SIZE = 13L;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws InterruptedException {
     member = BaseTestObject.createMemberNoId();
     tem.persist(member);
 
@@ -56,7 +56,7 @@ class MySharedDiaryRepositoryTest {
     tem.clear();
   }
 
-  private List<PublicDiaryEntity> createTestPublicDiaries() {
+  private List<PublicDiaryEntity> createTestPublicDiaries() throws InterruptedException {
     for (int i = 0; i < TEST_PUBLIC_DIARY_SIZE; i++) {
       DiaryEntity diary =
           BaseTestObject.createDiaryNoIdWithMemberAndCreatedDateTime(
@@ -69,6 +69,7 @@ class MySharedDiaryRepositoryTest {
               .build();
       tem.persist(diary);
       tem.persist(publicDiary);
+      Thread.sleep(1L);
     }
     tem.flush();
     tem.clear();
@@ -188,7 +189,7 @@ class MySharedDiaryRepositoryTest {
     PublicDiaryEntity expected = publicDiaries.get(3);
     Long memberId = expected.getMemberEntity().getId();
     DiaryEntity diaryEntity = expected.getDiaryEntity();
-    Instant requestDate = expected.getDiaryEntity().getDiaryCreatedTime();
+    Instant requestDate = expected.getCreatedTime();
 
     Optional<MySharedDiaryContentProjection> Optional_actual =
         mySharedDiaryRepository.findContent(memberId, requestDate);


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

### UTC 기반 로직 중, 잘 못 된 부분이 있어 로직을 수정하였습니다.
- Front 로직상, 일기 조회시 Spring에게 전달 받은 일기 작성 시간의 정확한 UTC 시간을 Spring에게 전달하기 어려워, Spring 서버에서 ```Bewteen```을 사용하여 일기를 조회합니다.
> DiaryRepository의 ```findDiaryEntityByMemberEntity_IdAndDiaryCreatedTimeBetween```
---
- 피드(공개 일기) 조회시 일기 [일기 작성 시간] 이 아닌, [피드 작성 시간] 기반으로 조회하며,  올바른 무한 스크롤 응답을 주기 위해
1. 시간이 동일하다면 id가 작은 다음 피드 (공개 일기)
2. 시간이 작다면 다음  피드 (공개 일기)
를 조회합니다.
> PublicDiaryRepository의 ```findNextContents``` 
---
- 나의 피드 또한 피드 무한 스크롤과 동일한 로직으로 수행됩니다.
>, MysharedDiaryRepository의 ```findNextPreviews```


## 리뷰 받고 싶은 내용
- 궁금하신 부분 있다면 알려주세요!


## 테스트 및 결과
- 로컬 테스트 확인 완료
- 피드 작성 시간 기반으로 무한 스크롤 응답이 있다 보니, 테스트에서 피드(공개 일기)를 작성할 때, 시간 차이를 두기 위해 1초간의 sleep을 적용했습니다. 

## 관련 스크린샷 및 참고자료 (Optional)

close #129 