### PR TITLE
OAuth2 인증 요청 정보 쿠키 전환

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
+++ b/src/main/java/com/heartsave/todaktodak_api/auth/service/AuthService.java
@@ -48,7 +48,10 @@ public class AuthService {
     if (!checkCache(id, refreshToken))
       throw new AuthException(
           AuthErrorSpec.ABNORMAL_ACCESS,
-          ErrorFieldBuilder.builder().add("reason", "캐시 토큰과 동일하지 않아요.").build());
+          ErrorFieldBuilder.builder()
+              .add("reason", "캐시 토큰과 동일하지 않아요.")
+              .add("cookie", refreshToken)
+              .build());
 
     // 토큰 재발급 및 쿠키 갱신
     var accessToken = JwtUtils.issueToken(user, ACCESS_TYPE);

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/CookieOauth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/component/oauth2/CookieOauth2AuthorizationRequestRepository.java
@@ -1,0 +1,66 @@
+package com.heartsave.todaktodak_api.common.security.component.oauth2;
+
+import com.heartsave.todaktodak_api.common.security.util.CookieUtils;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.util.StringUtils;
+
+public class CookieOauth2AuthorizationRequestRepository
+    implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+  public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+  public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+  private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+  // 쿠키에서 인증 정보 획득
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    Cookie cookie = CookieUtils.extractCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    if (cookie == null) return null;
+    return CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
+  }
+
+  // 인증 정보를 쿠키에 저장
+  @Override
+  public void saveAuthorizationRequest(
+      OAuth2AuthorizationRequest authorizationRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    if (authorizationRequest == null) {
+      CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+      CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+      return;
+    }
+    response.addCookie(
+        CookieUtils.createValidCookie(
+            OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+            CookieUtils.serialize(authorizationRequest),
+            COOKIE_EXPIRE_SECONDS));
+
+    String redirectUri = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+    if (StringUtils.hasText(REDIRECT_URI_PARAM_COOKIE_NAME)) {
+      response.addCookie(
+          CookieUtils.createValidCookie(
+              REDIRECT_URI_PARAM_COOKIE_NAME, redirectUri, COOKIE_EXPIRE_SECONDS));
+    }
+  }
+
+  // 인증 과정 완료 후 쿠키 처분
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(
+      HttpServletRequest request, HttpServletResponse response) {
+    OAuth2AuthorizationRequest authorizationRequest = this.loadAuthorizationRequest(request);
+    if (authorizationRequest != null) {
+      removeAuthorizationRequestCookies(request, response);
+    }
+    return authorizationRequest;
+  }
+
+  private void removeAuthorizationRequestCookies(
+      HttpServletRequest request, HttpServletResponse response) {
+    CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+  }
+}

--- a/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/heartsave/todaktodak_api/common/security/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.heartsave.todaktodak_api.common.security.component.AuthenticationEntr
 import com.heartsave.todaktodak_api.common.security.component.jwt.JwtAuthFilter;
 import com.heartsave.todaktodak_api.common.security.component.jwt.JwtLogoutFilter;
 import com.heartsave.todaktodak_api.common.security.component.jwt.JwtValidationFilter;
+import com.heartsave.todaktodak_api.common.security.component.oauth2.CookieOauth2AuthorizationRequestRepository;
 import com.heartsave.todaktodak_api.common.security.component.oauth2.OAuth2SuccessHandler;
 import com.heartsave.todaktodak_api.common.security.component.oauth2.Oauth2FailureHandler;
 import com.heartsave.todaktodak_api.common.security.component.oauth2.TodakOauth2UserDetailsService;
@@ -59,6 +60,10 @@ public class SecurityConfig {
         .oauth2Login(
             (oauth2) ->
                 oauth2
+                    .authorizationEndpoint(
+                        ep ->
+                            ep.authorizationRequestRepository(
+                                new CookieOauth2AuthorizationRequestRepository()))
                     .userInfoEndpoint((config) -> config.userService(oauth2UserDetailsService))
                     .successHandler(oAuth2SuccessHandler)
                     .failureHandler(oauth2FailureHandler))


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항
# OAuth2 인증 요청 정보를 쿠키 형식으로 관리합니다.

1. 사용자가 OAuth2 로그인 요청시, 인증 요청 정보를 쿠키로 생성
2. 추후 리다이렉트 될 때, 쿠키에 인증 요청 정보가 존재하는지 확인
3. OAuth2 로그인 완료 시, 인증 요청 정보 쿠키 삭제

## 관련 스크린샷 및 참고자료 (Optional)
close #141 